### PR TITLE
fix: Use non-encoded url for potplayer

### DIFF
--- a/src/pages/home/previews/video.tsx
+++ b/src/pages/home/previews/video.tsx
@@ -14,7 +14,7 @@ import { isMobile } from "~/utils/compatibility";
 
 const players: { icon: string; scheme: string }[] = [
   { icon: "iina", scheme: "iina://weblink?url=$url" },
-  { icon: "potplayer", scheme: "potplayer://$e_url" },
+  { icon: "potplayer", scheme: "potplayer://$url" },
   { icon: "vlc", scheme: "vlc://$url" },
   { icon: "nplayer", scheme: "nplayer-$url" },
   {


### PR DESCRIPTION
Using an encoded url for Potplayer will cause playback errors.
![image](https://user-images.githubusercontent.com/26916265/192117816-783fdece-bd6a-4713-b923-96e617b1edfb.png)
