### PR TITLE
feat: use Cmd+K for search on Mac

### DIFF
--- a/src/pages/home/folder/Search.tsx
+++ b/src/pages/home/folder/Search.tsx
@@ -28,6 +28,7 @@ import {
   hoverColor,
   pathJoin,
 } from "~/utils"
+import { isMac } from "~/utils/compatibility"
 import { getIconByObj } from "~/utils/icon"
 
 const SearchResult = (props: SearchNode) => {
@@ -89,7 +90,7 @@ const Search = () => {
   }
   bus.on("tool", handler)
   const searchEvent = (e: KeyboardEvent) => {
-    if (e.ctrlKey && e.key.toLowerCase() === "k") {
+    if ((e.ctrlKey || (isMac && e.metaKey)) && e.key.toLowerCase() === "k") {
       e.preventDefault()
       onToggle()
     }

--- a/src/pages/home/header/Header.tsx
+++ b/src/pages/home/header/Header.tsx
@@ -13,6 +13,7 @@ import { CenterLoading } from "~/components"
 import { Container } from "../Container"
 import { bus } from "~/utils"
 import { Layout } from "./layout"
+import { isMac } from "~/utils/compatibility"
 
 export const Header = () => {
   const logos = getSetting("logo").split("\n")
@@ -58,7 +59,7 @@ export const Header = () => {
                 >
                   <Icon as={BsSearch} />
                   <HStack>
-                    <Kbd>Ctrl</Kbd>
+                    {isMac ? <Kbd>Cmd</Kbd> : <Kbd>Ctrl</Kbd>}
                     <Kbd>K</Kbd>
                   </HStack>
                 </HStack>

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -7,3 +7,4 @@ export const isMobile =
 export const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent)
 export const isWechat = /MicroMessenger/i.test(userAgent)
 export const isIE = /MSIE|Trident/i.test(userAgent)
+export const isMac = (window?.navigator?.platform ?? "")?.includes("Mac")


### PR DESCRIPTION
If Mac is detected, additionally allow `Cmd`+`K` as the keyboard shortcut for toggling the search popup.