### PR TITLE
Fixed subtitle loss when switching videos with different resolutions

### DIFF
--- a/src/pages/home/previews/aliyun_video.tsx
+++ b/src/pages/home/previews/aliyun_video.tsx
@@ -174,6 +174,12 @@ const Preview = () => {
           replace(videos[index + 1].name)
         }
       })
+      // Fixed subtitle loss when switching videos with different resolutions
+      if(subtitle){
+        player.on("video:play", (url) => {
+          player.subtitle.url =  proxyLink(subtitle, true);
+      });
+      }
     })
   })
   onCleanup(() => {


### PR DESCRIPTION
Due to switching video connections with different resolutions, subtitles are lost