### PR TITLE
feat: preview plain html file by HTML render first

### DIFF
--- a/src/pages/home/previews/index.ts
+++ b/src/pages/home/previews/index.ts
@@ -16,6 +16,11 @@ export type PreviewComponent = Pick<Preview, "name" | "component">
 
 const previews: Preview[] = [
   {
+    name: "HTML render",
+    exts: ["html"],
+    component: lazy(() => import("./html")),
+  },
+  {
     name: "Aliyun Video Previewer",
     type: ObjType.VIDEO,
     provider: /^Aliyundrive(Open)?$/,
@@ -41,11 +46,6 @@ const previews: Preview[] = [
     type: ObjType.TEXT,
     exts: ["url"],
     component: lazy(() => import("./text-editor")),
-  },
-  {
-    name: "HTML render",
-    exts: ["html"],
-    component: lazy(() => import("./html")),
   },
   {
     name: "Image",


### PR DESCRIPTION
<img width="943" alt="image" src="https://github.com/alist-org/alist-web/assets/41264693/d4e5f045-77e5-42cc-90c9-c05379b41f97">

By default, plain html file now rendered by **Markdown**, it would be easier to use if the **HTML render** as the first preview engine

<img width="939" alt="image" src="https://github.com/alist-org/alist-web/assets/41264693/5a3d0c52-4103-4e4d-a860-82babc3cad3b">

<img width="921" alt="image" src="https://github.com/alist-org/alist-web/assets/41264693/b0938f81-00be-4279-93a7-ab138d5a0f55">
