### PR TITLE
fix(Notify): 修复关闭按钮和文字重合的问题 & feat(Rename): 重命名时默认选中后缀名前的部分

### DIFF
--- a/src/components/ModalInput.tsx
+++ b/src/components/ModalInput.tsx
@@ -10,13 +10,14 @@ import {
   Textarea,
   FormHelperText,
 } from "@hope-ui/solid"
-import { createSignal, JSXElement, Show } from "solid-js"
+import { createSignal, JSXElement, Show, createEffect, onCleanup } from "solid-js"
 import { useT } from "~/hooks"
 import { notify } from "~/utils"
 export type ModalInputProps = {
   opened: boolean
   onClose: () => void
   title: string
+  isRenamingFile?: boolean
   onSubmit?: (text: string) => void
   type?: string
   defaultValue?: string
@@ -25,16 +26,50 @@ export type ModalInputProps = {
   topSlot?: JSXElement
 }
 export const ModalInput = (props: ModalInputProps) => {
-  const [value, setValue] = createSignal(props.defaultValue ?? "")
-  const t = useT()
+  const [value, setValue] = createSignal(props.defaultValue ?? "");
+  const t = useT();
+
+  let inputRef: HTMLInputElement | HTMLTextAreaElement;
+
+  const handleFocus = () => {
+    // Find the position of the first dot (".") in the value
+    const dotIndex = value().lastIndexOf(".");
+
+    setTimeout(() => {
+      // If a dot exists and it is not the first character, select from start to dotIndex
+      // And it must be a file, not a folder
+      if (dotIndex > 0 && props.isRenamingFile) {
+        inputRef.setSelectionRange(0, dotIndex);
+      } else {
+        // If there's no dot or it's the first character, select the entire value
+        inputRef.select();
+      }
+    }, 10); // To prevent default select behavior from interfering
+  };
+
+  createEffect(() => {
+    if (inputRef) {
+      inputRef.focus();
+      handleFocus();
+    }
+
+    // Cleanup function to clear the selection range before unmounting
+    onCleanup(() => {
+      if (inputRef) {
+        inputRef.setSelectionRange(0, 0);
+      }
+    });
+  });
+
   const submit = () => {
     if (!value()) {
-      notify.warning(t("global.empty_input"))
-      return
+      notify.warning(t("global.empty_input"));
+      return;
     }
-    props.onSubmit?.(value())
-    setValue("")
-  }
+    props.onSubmit?.(value());
+    setValue("");
+  };
+
   return (
     <Modal
       blockScrollOnMount={false}
@@ -55,12 +90,14 @@ export const ModalInput = (props: ModalInputProps) => {
                 id="modal-input"
                 type={props.type}
                 value={value()}
+                ref={(el) => (inputRef = el)}
                 onInput={(e) => {
-                  setValue(e.currentTarget.value)
+                  setValue(e.currentTarget.value);
                 }}
+                onFocus={handleFocus}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
-                    submit()
+                    submit();
                   }
                 }}
               />
@@ -69,9 +106,11 @@ export const ModalInput = (props: ModalInputProps) => {
             <Textarea
               id="modal-input"
               value={value()}
+              ref={(el) => (inputRef = el)}
               onInput={(e) => {
-                setValue(e.currentTarget.value)
+                setValue(e.currentTarget.value);
               }}
+              onFocus={handleFocus}
             />
           </Show>
           <Show when={props.tips}>
@@ -88,5 +127,5 @@ export const ModalInput = (props: ModalInputProps) => {
         </ModalFooter>
       </ModalContent>
     </Modal>
-  )
-}
+  );
+};

--- a/src/pages/home/toolbar/Rename.tsx
+++ b/src/pages/home/toolbar/Rename.tsx
@@ -34,6 +34,7 @@ export const Rename = () => {
     <Show when={isOpen()}>
       <ModalInput
         title="home.toolbar.input_new_name"
+        isRenamingFile={!selectedObjs()[0].is_dir}
         opened={isOpen()}
         onClose={onClose}
         defaultValue={selectedObjs()[0]?.name ?? ""}

--- a/src/utils/notify.tsx
+++ b/src/utils/notify.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   CloseButton,
+  Flex,
   // Alert,
   // AlertDescription,
   // AlertIcon,
@@ -10,6 +11,8 @@ import {
 } from "@hope-ui/solid"
 import { JSXElement } from "solid-js"
 import { alphaBgColor, firstUpperCase } from "."
+import { marginPropNames } from "@hope-ui/solid/dist/styled-system/props/margin"
+import { BsDisplay } from "solid-icons/bs"
 
 const notify = {
   render: (element: JSXElement) => {
@@ -17,22 +20,26 @@ const notify = {
       render: (props) => {
         return (
           <Box
-            class="notify-render"
             css={{
+              display: "flex",
               backdropFilter: "blur(8px)",
+              backgroundColor: alphaBgColor(),
+              boxShadow: "$md",
+              borderRadius: "$lg",
+              padding: "$3",
             }}
-            bgColor={alphaBgColor()}
-            shadow="$md"
-            rounded="$lg"
-            p="$3"
           >
-            <CloseButton
-              pos="absolute"
-              right="$2"
-              top="$2"
-              onClick={props.close}
-            />
-            {element}
+            <div style={{ flexGrow: 1, display: "flex", alignItems: "center" }}>
+              <div style={{ margin: "auto" }}>{element}</div>
+            </div>
+            <div style={{ display: "inline-block", padding: "5px" }}>
+              <CloseButton
+                style={{ float: "right" }}
+                right="$2"
+                top="$2"
+                onClick={props.close}
+              />
+            </div>
           </Box>
         )
       },

--- a/src/utils/notify.tsx
+++ b/src/utils/notify.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   CloseButton,
-  Flex,
   // Alert,
   // AlertDescription,
   // AlertIcon,
@@ -11,8 +10,6 @@ import {
 } from "@hope-ui/solid"
 import { JSXElement } from "solid-js"
 import { alphaBgColor, firstUpperCase } from "."
-import { marginPropNames } from "@hope-ui/solid/dist/styled-system/props/margin"
-import { BsDisplay } from "solid-icons/bs"
 
 const notify = {
   render: (element: JSXElement) => {


### PR DESCRIPTION
### 修复关闭按钮和文字重合的问题

在某些情形下，如设置站点公告为一小段非标题文字且长度较长：

![截屏2023-08-03 20 00 37](https://github.com/alist-org/alist-web/assets/60802943/81030668-9e45-4137-85c2-4e6a65191236)

就会出现如图，关闭按钮和文字重合的问题。

修复后：

![截屏2023-08-03 20 10 38](https://github.com/alist-org/alist-web/assets/60802943/a1ffb808-f9f1-4ede-8479-57d362c9dc70)

### 重命名默认选中后缀名前的部分

![截屏2023-08-04 10 29 34](https://github.com/alist-org/alist-web/assets/60802943/8c1d8bbf-4a8d-4f99-b722-2b556ad1be57)

仅在 `.` 出现在非第一个（如 `.DS_Store` 就全选中）、并且是文件（而非文件夹）、并且是重命名窗口才会触发。

