### PR TITLE
Modify epub static resource link

### DIFF
--- a/public/static/epub.js/viewer.html
+++ b/public/static/epub.js/viewer.html
@@ -6,12 +6,12 @@
     <title>EPUB.js viewer</title>
 
     <script
-      src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"
+      src="https://npm.elemecdn.com/jszip@3.10.1/dist/jszip.min.js"
       integrity="sha256-rMfkFFWoB2W1/Zx+4bgHim0WC7vKRVrq6FTeZclH1Z4="
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdn.jsdelivr.net/npm/epubjs@0.3.93/dist/epub.min.js"
+      src="https://npm.elemecdn.com/epubjs@0.3.93/dist/epub.min.js"
       integrity="sha256-BurhV0UQe0qlCMlVOCdSUfab+58RdWIfxFjZ9C7QgtQ="
       crossorigin="anonymous"
     ></script>


### PR DESCRIPTION
`jsdelivr` 在使用时连接不太稳定，就更换为`elemecdn`

- 比对了文件`MD5` `SHA1` 都是一样的，更换链接后`integrity`应该不用更换吧？

>文件:eml-0.3.93-ele-epub.min.js **(新)**
大小: 223875 字节
MD5: 0C49D4A46630BF7864E5E1B74DB07914
SHA1: 0C1C526BA0699BDFEEE72F52E9993DB68D70B262
CRC32: 5FFFB62E
>
>文件: jsd-0.3.93-jsd-epub.min.js **(旧)**
大小: 223875 字节
MD5: 0C49D4A46630BF7864E5E1B74DB07914
SHA1: 0C1C526BA0699BDFEEE72F52E9993DB68D70B262
CRC32: 5FFFB62E

>文件: elm-jszip.min.js **(新)**
大小: 97630 字节
MD5: B5D02B3F0BF3AE026451909419DF07BB
SHA1: C96375D50E72B199AA54DE7B9AD908FD5A2DC7BC
CRC32: D538C831
>
>文件: jsd-jszip.min.js **(旧)**
大小: 97630 字节
MD5: B5D02B3F0BF3AE026451909419DF07BB
SHA1: C96375D50E72B199AA54DE7B9AD908FD5A2DC7BC
CRC32: D538C831

