### PR TITLE
feat: 删除submodules中的solid-router

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "solid-router"]
-	path = solid-router
-	url = https://github.com/alist-org/solid-router

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 dist/
-solid-router/
 pnpm-lock.yaml
 .husky
 .prettierignore

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@motionone/solid": "^10.14.1",
     "@solid-primitives/i18n": "^1.1.0",
     "@solid-primitives/storage": "^1.3.1",
+    "@solidjs/router": "^0.8.3",
     "@stitches/core": "^1.2.8",
     "aplayer": "^1.10.1",
     "artplayer": "^4.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@solid-primitives/storage':
     specifier: ^1.3.1
     version: 1.3.1(solid-js@1.4.8)
+  '@solidjs/router':
+    specifier: ^0.8.3
+    version: 0.8.3(solid-js@1.4.8)
   '@stitches/core':
     specifier: ^1.2.8
     version: 1.2.8
@@ -656,6 +659,14 @@ packages:
     resolution: {integrity: sha512-LCU3tVrJmyRqJ0ocG5uCEuUNqmGkcAC+cWpDEE49AuvtehkdQfv4CfqvdNJgs3eoQRQhLOrVcgd1bHFJY4lsrQ==}
     peerDependencies:
       solid-js: ^1.4.1
+    dependencies:
+      solid-js: 1.4.8
+    dev: false
+
+  /@solidjs/router@0.8.3(solid-js@1.4.8):
+    resolution: {integrity: sha512-oJuqQo10rVTiQYhe1qXIG1NyZIZ2YOwHnlLc8Xx+g/iJhFCJo1saLOIrD/Dkh2fpIaIny5ZMkz1cYYqoTYGJbg==}
+    peerDependencies:
+      solid-js: ^1.5.3
     dependencies:
       solid-js: 1.4.8
     dev: false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
     "noEmit": true,
     "isolatedModules": false,
     "paths": {
-      "~/*": ["./src/*"],
-      "@solidjs/router": ["./solid-router/src/index.tsx"]
+      "~/*": ["./src/*"]
     },
     "resolveJsonModule": true
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "~": path.resolve(__dirname, "src"),
-      "@solidjs/router": path.resolve(__dirname, "solid-router/src"),
     },
   },
   plugins: [


### PR DESCRIPTION
看了下solid-router，发现新版的solid-router中，去除了urlDecode的代码，所以可以直接使用官方的solid-router了
改动：删除solid-router相关的submodules

官方改动参考：
https://github.com/solidjs/solid-router/commit/d87b66b30ff68ed48d3f1cb086f681065ca3e8e5