### PR TITLE
fix: 改善EPUB文件在预览窗口的显示效果

### DIFF
--- a/public/static/epub.js/viewer.html
+++ b/public/static/epub.js/viewer.html
@@ -303,7 +303,7 @@
   <body>
     <!-- <div id="title"></div> -->
     <select id="toc"></select>
-    <div id="viewer" class="spreads"></div>
+    <div id="viewer" class="spreads" style="top: 0px"></div>
     <a id="prev" href="#prev" class="arrow">‹</a>
     <a id="next" href="#next" class="arrow">›</a>
 


### PR DESCRIPTION
修改前，在预览epub文件时，在iframe页面无法看到目录框，需要点击全屏按钮或者在新窗口打开，才可以看到目录框。修改后在预览页直接可以看到目录框，方便使用。
![image](https://github.com/alist-org/alist-web/assets/17337930/75a01153-3ad4-4bc0-b48f-48ead07ece71)
