### PR TITLE
docs: change outdated repository link to alist-org

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/alist-org/alist-web.git"
   },
   "bugs": {
-    "url": "https://github.com/Xhofe/alist/issues"
+    "url": "https://github.com/alist-org/alist/issues"
   },
   "files": [
     "dist"

--- a/src/pages/home/Footer.tsx
+++ b/src/pages/home/Footer.tsx
@@ -10,7 +10,7 @@ export const Footer = () => {
   return (
     <VStack class="footer" w="$full" py="$4">
       <HStack spacing="$1">
-        <Anchor href="https://github.com/Xhofe/alist" external>
+        <Anchor href="https://github.com/alist-org/alist" external>
           {t("home.footer.powered_by")}
         </Anchor>
         <span>|</span>

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -8,7 +8,7 @@ export const setSettings = (items: Record<string, string>) => {
   })
   const version = settings["version"] || "Unknown"
   console.log(
-    `%c AList %c ${version} %c https://github.com/Xhofe/alist`,
+    `%c AList %c ${version} %c https://github.com/alist-org/alist`,
     "color: #fff; background: #5f5f5f",
     "color: #fff; background: #70c6be",
     "",


### PR DESCRIPTION
我是因 https://github.com/alist-org/alist-web/blob/972fcf5e2dbf7c0e72e59baf16b1e6173d4a1546/src/pages/home/Footer.tsx#L13 而注意到这一点的

相关的PR还包括：

* https://github.com/alist-org/alist/pull/6007