### PR TITLE
fix: paused video will play automatically after switching url

### DIFF
--- a/src/pages/home/previews/aliyun_video.tsx
+++ b/src/pages/home/previews/aliyun_video.tsx
@@ -372,7 +372,9 @@ const Preview = () => {
       option.quality = quality
       player.quality = quality
       curSeek = player.currentTime
+      let curPlaying = player.playing
       await player.switchUrl(quality[quality.length - 1].url)
+      if (!curPlaying) player.pause()
       setTimeout(() => {
         player.seek = curSeek
       }, 1000)


### PR DESCRIPTION
修复 issue [6045](https://github.com/alist-org/alist/issues/6045)
artplayer 调用 switchUrl 后，原本暂停的视频会播放