### PR TITLE
feat: block actions of router while checkbox enabled

### DIFF
--- a/src/pages/home/folder/GridItem.tsx
+++ b/src/pages/home/folder/GridItem.tsx
@@ -2,7 +2,7 @@ import { Center, VStack, Icon, Text, Checkbox } from "@hope-ui/solid"
 import { Motion } from "@motionone/solid"
 import { useContextMenu } from "solid-contextmenu"
 import { batch, createMemo, createSignal, Show } from "solid-js"
-import { CenterLoading, ImageWithError } from "~/components"
+import { CenterLoading, LinkWithPush, ImageWithError } from "~/components"
 import { usePath, useRouter, useUtil } from "~/hooks"
 import {
   checkboxOpen,
@@ -54,14 +54,18 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
           transform: "scale(1.06)",
           bgColor: hoverColor(),
         }}
-        cursor="pointer"
-        userSelect="none"
-        onClick={() => {
-          if (checkboxOpen()) {
-            selectIndex(props.index, !props.obj.selected)
+        as={LinkWithPush}
+        href={props.obj.name}
+        // @ts-ignore
+        on:click={(e: PointerEvent) => {
+          if (!checkboxOpen()) return
+          e.preventDefault()
+          if (e.altKey) {
+            // click with alt/option key
+            to(pushHref(props.obj.name))
             return
           }
-          to(pushHref(props.obj.name))
+          selectIndex(props.index, !props.obj.selected)
         }}
         onMouseEnter={() => {
           setHover(true)

--- a/src/pages/home/folder/GridItem.tsx
+++ b/src/pages/home/folder/GridItem.tsx
@@ -106,7 +106,7 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
               left="$1"
               top="$1"
               // colorScheme="neutral"
-              // @ts-ignore
+              // @ts-expect-error
               on:click={(e) => {
                 e.stopPropagation()
               }}

--- a/src/pages/home/folder/GridItem.tsx
+++ b/src/pages/home/folder/GridItem.tsx
@@ -2,8 +2,8 @@ import { Center, VStack, Icon, Text, Checkbox } from "@hope-ui/solid"
 import { Motion } from "@motionone/solid"
 import { useContextMenu } from "solid-contextmenu"
 import { batch, createMemo, createSignal, Show } from "solid-js"
-import { CenterLoading, LinkWithPush, ImageWithError } from "~/components"
-import { usePath, useUtil } from "~/hooks"
+import { CenterLoading, ImageWithError } from "~/components"
+import { usePath, useRouter, useUtil } from "~/hooks"
 import {
   checkboxOpen,
   getMainColor,
@@ -33,6 +33,7 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
     () => checkboxOpen() && (hover() || props.obj.selected),
   )
   const { show } = useContextMenu({ id: 1 })
+  const { pushHref, to } = useRouter()
   return (
     <Motion.div
       initial={{ opacity: 0, scale: 0.9 }}
@@ -53,8 +54,15 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
           transform: "scale(1.06)",
           bgColor: hoverColor(),
         }}
-        as={LinkWithPush}
-        href={props.obj.name}
+        cursor="pointer"
+        userSelect="none"
+        onClick={() => {
+          if (checkboxOpen()) {
+            selectIndex(props.index, !props.obj.selected)
+            return
+          }
+          to(pushHref(props.obj.name))
+        }}
         onMouseEnter={() => {
           setHover(true)
           setPathAs(props.obj.name, props.obj.is_dir, true)
@@ -79,6 +87,7 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
           w="$full"
           // @ts-ignore
           on:click={(e) => {
+            if (checkboxOpen()) return
             if (props.obj.type === ObjType.IMAGE) {
               e.stopPropagation()
               e.preventDefault()

--- a/src/pages/home/folder/ImageItem.tsx
+++ b/src/pages/home/folder/ImageItem.tsx
@@ -2,7 +2,7 @@ import { Center, VStack, Icon, Checkbox } from "@hope-ui/solid"
 import { Motion } from "@motionone/solid"
 import { useContextMenu } from "solid-contextmenu"
 import { batch, createMemo, createSignal, Show } from "solid-js"
-import { CenterLoading, LinkWithPush, ImageWithError } from "~/components"
+import { CenterLoading, ImageWithError } from "~/components"
 import { useLink, usePath, useUtil } from "~/hooks"
 import { checkboxOpen, getMainColor, selectAll, selectIndex } from "~/store"
 import { ObjType, StoreObj } from "~/types"
@@ -82,12 +82,13 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
             src={rawLink(props.obj)}
             loading="lazy"
             cursor="pointer"
-            onClick={() => {
-              if (checkboxOpen()) {
-                selectIndex(props.index, !props.obj.selected)
+            // @ts-ignore
+            on:click={(e: PointerEvent) => {
+              if (!checkboxOpen() || e.altKey) {
+                bus.emit("gallery", props.obj.name)
                 return
               }
-              bus.emit("gallery", props.obj.name)
+              selectIndex(props.index, !props.obj.selected)
             }}
           />
         </Center>

--- a/src/pages/home/folder/ImageItem.tsx
+++ b/src/pages/home/folder/ImageItem.tsx
@@ -82,7 +82,7 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
             src={rawLink(props.obj)}
             loading="lazy"
             cursor="pointer"
-            // @ts-ignore
+            // @ts-expect-error
             on:click={(e: PointerEvent) => {
               if (!checkboxOpen() || e.altKey) {
                 bus.emit("gallery", props.obj.name)

--- a/src/pages/home/folder/ImageItem.tsx
+++ b/src/pages/home/folder/ImageItem.tsx
@@ -81,7 +81,12 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
             fallbackErr={objIcon}
             src={rawLink(props.obj)}
             loading="lazy"
+            cursor="pointer"
             onClick={() => {
+              if (checkboxOpen()) {
+                selectIndex(props.index, !props.obj.selected)
+                return
+              }
               bus.emit("gallery", props.obj.name)
             }}
           />

--- a/src/pages/home/folder/ListItem.tsx
+++ b/src/pages/home/folder/ListItem.tsx
@@ -2,8 +2,7 @@ import { Checkbox, HStack, Icon, Text } from "@hope-ui/solid"
 import { Motion } from "@motionone/solid"
 import { useContextMenu } from "solid-contextmenu"
 import { batch, Show } from "solid-js"
-import { LinkWithPush } from "~/components"
-import { usePath, useUtil } from "~/hooks"
+import { usePath, useRouter, useUtil } from "~/hooks"
 import {
   checkboxOpen,
   getMainColor,
@@ -34,6 +33,7 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
   }
   const { setPathAs } = usePath()
   const { show } = useContextMenu({ id: 1 })
+  const { pushHref, to } = useRouter()
   return (
     <Motion.div
       initial={{ opacity: 0, scale: 0.95 }}
@@ -53,8 +53,15 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
           transform: "scale(1.01)",
           bgColor: hoverColor(),
         }}
-        as={LinkWithPush}
-        href={props.obj.name}
+        cursor="pointer"
+        userSelect="none"
+        onClick={() => {
+          if (checkboxOpen()) {
+            selectIndex(props.index, !props.obj.selected)
+            return
+          }
+          to(pushHref(props.obj.name))
+        }}
         onMouseEnter={() => {
           setPathAs(props.obj.name, props.obj.is_dir, true)
         }}

--- a/src/pages/home/folder/ListItem.tsx
+++ b/src/pages/home/folder/ListItem.tsx
@@ -58,7 +58,7 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
         }}
         as={LinkWithPush}
         href={props.obj.name}
-        // @ts-ignore
+        // @ts-expect-error
         on:click={(e: PointerEvent) => {
           if (!checkboxOpen()) return
           e.preventDefault()
@@ -103,7 +103,7 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
             color={getMainColor()}
             as={getIconByObj(props.obj)}
             mr="$1"
-            // @ts-ignore
+            // @ts-expect-error
             on:click={(e) => {
               if (props.obj.type === ObjType.IMAGE) {
                 e.stopPropagation()

--- a/src/pages/home/folder/ListItem.tsx
+++ b/src/pages/home/folder/ListItem.tsx
@@ -2,6 +2,7 @@ import { Checkbox, HStack, Icon, Text } from "@hope-ui/solid"
 import { Motion } from "@motionone/solid"
 import { useContextMenu } from "solid-contextmenu"
 import { batch, Show } from "solid-js"
+import { LinkWithPush } from "~/components"
 import { usePath, useRouter, useUtil } from "~/hooks"
 import {
   checkboxOpen,
@@ -53,14 +54,18 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
           transform: "scale(1.01)",
           bgColor: hoverColor(),
         }}
-        cursor="pointer"
-        userSelect="none"
-        onClick={() => {
-          if (checkboxOpen()) {
-            selectIndex(props.index, !props.obj.selected)
+        as={LinkWithPush}
+        href={props.obj.name}
+        // @ts-ignore
+        on:click={(e: PointerEvent) => {
+          if (!checkboxOpen()) return
+          e.preventDefault()
+          if (e.altKey) {
+            // click with alt/option key
+            to(pushHref(props.obj.name))
             return
           }
-          to(pushHref(props.obj.name))
+          selectIndex(props.index, !props.obj.selected)
         }}
         onMouseEnter={() => {
           setPathAs(props.obj.name, props.obj.is_dir, true)


### PR DESCRIPTION
相关 issue [#5989](https://github.com/alist-org/alist/issues/5989) [#6021](https://github.com/alist-org/alist/issues/6021)

具体改动如下
- 在显示多选框时，优先触发选择操作，防止跳进更深层的文件夹里


演示效果如下

https://github.com/alist-org/alist-web/assets/55272688/ad24f37c-fbae-44c4-bebe-3d0dcfda1e18

https://github.com/alist-org/alist-web/assets/55272688/9c724c4b-4cce-40bb-8824-2343488631ef

