### PR TITLE
fix: disable markdown toc on default

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -24,7 +24,7 @@ type TocItem = { indent: number; text: string; tagName: string; key: string }
 const [isTocVisible, setVisible] = createSignal(false)
 const [isTocDisabled, setTocDisabled] = createStorageSignal(
   "isMarkdownTocDisabled",
-  false,
+  true,
   {
     serializer: (v: boolean) => JSON.stringify(v),
     deserializer: (v) => JSON.parse(v),


### PR DESCRIPTION
refer to https://github.com/alist-org/alist-web/pull/150#issuecomment-1964282300

改动如下
- Markdown 大纲栏改为默认不显示