### PR TITLE
fix: additional logic of optional open item on checkbox

### DIFF
--- a/src/pages/home/folder/GridItem.tsx
+++ b/src/pages/home/folder/GridItem.tsx
@@ -62,8 +62,7 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
         on:click={(e: MouseEvent) => {
           if (!checkboxOpen()) return
           e.preventDefault()
-          if (e.altKey) {
-            // click with alt/option key
+          if (isShouldOpenItem()) {
             to(pushHref(props.obj.name))
             return
           }

--- a/src/pages/home/folder/ImageItem.tsx
+++ b/src/pages/home/folder/ImageItem.tsx
@@ -86,8 +86,8 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
             cursor={
               !checkboxOpen() || isShouldOpenItem() ? "pointer" : "default"
             }
-            on:click={(e: MouseEvent) => {
-              if (!checkboxOpen() || e.altKey) {
+            on:click={() => {
+              if (!checkboxOpen() || isShouldOpenItem()) {
                 bus.emit("gallery", props.obj.name)
                 return
               }

--- a/src/pages/home/folder/ListItem.tsx
+++ b/src/pages/home/folder/ListItem.tsx
@@ -65,7 +65,6 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
           if (!checkboxOpen()) return
           e.preventDefault()
           if (isShouldOpenItem()) {
-            // click with alt/option key
             to(pushHref(props.obj.name))
             return
           }

--- a/src/pages/home/folder/helper.ts
+++ b/src/pages/home/folder/helper.ts
@@ -1,5 +1,6 @@
 import { createKeyHold } from "@solid-primitives/keyboard"
 import { createEffect, createSignal } from "solid-js"
+import { isMac } from "~/utils/compatibility"
 import { local } from "~/store"
 
 export function useOpenItemWithCheckbox() {
@@ -7,6 +8,7 @@ export function useOpenItemWithCheckbox() {
     local["open_item_on_checkbox"] === "direct",
   )
   const isAltKeyPressed = createKeyHold("Alt")
+  const isMetaKeyPressed = createKeyHold("Meta")
   const isControlKeyPressed = createKeyHold("Control")
   createEffect(() => {
     switch (local["open_item_on_checkbox"]) {
@@ -15,7 +17,10 @@ export function useOpenItemWithCheckbox() {
         break
       }
       case "with_ctrl": {
-        setShouldOpen(isControlKeyPressed())
+        // FYI why should use metaKey on a Mac
+        // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/ctrlKey
+        // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/metaKey
+        setShouldOpen(isMac ? isMetaKeyPressed() : isControlKeyPressed())
         break
       }
       case "with_alt": {

--- a/src/store/local_settings.ts
+++ b/src/store/local_settings.ts
@@ -56,7 +56,7 @@ export const initialLocalSettings = [
     key: "open_item_on_checkbox",
     default: "direct",
     type: "select",
-    options: ["direct", "with_alt"], // "with_ctrl",? mac's control key can't be prevented
+    options: ["direct", "with_alt", "with_ctrl"],
   },
 ]
 export type LocalSetting = (typeof initialLocalSettings)[number]


### PR DESCRIPTION
refer to https://github.com/alist-org/alist-web/pull/151#issuecomment-1970458436

- 补充修改：`网格模式` 和 `图片模式` 下，启用复选框时直接打开的逻辑
- 补充修改：`open_item_on_checkbox` 的 `with_ctrl` 选项