### PR TITLE
fix: hide matched files/folders in sidebar

### DIFF
--- a/src/components/FolderTree.tsx
+++ b/src/components/FolderTree.tsx
@@ -28,7 +28,7 @@ import {
   createEffect,
   on,
 } from "solid-js"
-import { useFetch, useT } from "~/hooks"
+import { useFetch, useT, useUtil } from "~/hooks"
 import { getMainColor, password } from "~/store"
 import { Obj } from "~/types"
 import {
@@ -49,6 +49,7 @@ export interface FolderTreeProps {
   autoOpen?: boolean
   handle?: (handler: FolderTreeHandler) => void
   showEmptyIcon?: boolean
+  showHiddenFolder?: boolean
 }
 interface FolderTreeContext extends Omit<FolderTreeProps, "handle"> {
   value: Accessor<string>
@@ -69,6 +70,7 @@ export const FolderTree = (props: FolderTreeProps) => {
           autoOpen: props.autoOpen ?? false,
           forceRoot: props.forceRoot ?? false,
           showEmptyIcon: props.showEmptyIcon ?? false,
+          showHiddenFolder: props.showHiddenFolder ?? true,
         }}
       >
         <FolderTreeNode path="/" />
@@ -78,9 +80,16 @@ export const FolderTree = (props: FolderTreeProps) => {
 }
 
 const FolderTreeNode = (props: { path: string }) => {
+  const { isHide } = useUtil()
   const [children, setChildren] = createSignal<Obj[]>()
-  const { value, onChange, forceRoot, autoOpen, showEmptyIcon } =
-    useContext(context)!
+  const {
+    value,
+    onChange,
+    forceRoot,
+    autoOpen,
+    showEmptyIcon,
+    showHiddenFolder,
+  } = useContext(context)!
   const emptyIconVisible = () =>
     Boolean(showEmptyIcon && children() !== undefined && !children()?.length)
   const [loading, fetchDirs] = useFetch(() =>
@@ -162,7 +171,9 @@ const FolderTreeNode = (props: { path: string }) => {
         <VStack mt="$1" pl="$4" alignItems="start" spacing="$1">
           <For each={children()}>
             {(item) => (
-              <FolderTreeNode path={pathJoin(props.path, item.name)} />
+              <Show when={showHiddenFolder || !isHide(item)}>
+                <FolderTreeNode path={pathJoin(props.path, item.name)} />
+              </Show>
             )}
           </For>
         </VStack>

--- a/src/components/FolderTree.tsx
+++ b/src/components/FolderTree.tsx
@@ -80,7 +80,7 @@ export const FolderTree = (props: FolderTreeProps) => {
 }
 
 const FolderTreeNode = (props: { path: string }) => {
-  const { isHide } = useUtil()
+  const { isHidePath } = useUtil()
   const [children, setChildren] = createSignal<Obj[]>()
   const {
     value,
@@ -112,73 +112,76 @@ const FolderTreeNode = (props: { path: string }) => {
   }
   const { isOpen, onToggle } = createDisclosure()
   const active = () => value() === props.path
+  const isMatchedFolder = createMatcher(props.path)
   const checkIfShouldOpen = async (pathname: string) => {
     if (!autoOpen) return
-    if (createMatcher(props.path)(pathname)) {
+    if (isMatchedFolder(pathname)) {
       if (!isOpen()) onToggle()
       if (!isLoaded) load()
     }
   }
   createEffect(on(value, checkIfShouldOpen))
+  const isHiddenFolder = () =>
+    isHidePath(props.path) && !isMatchedFolder(value())
   return (
-    <Box>
-      <HStack spacing="$2">
-        <Show
-          when={!loading()}
-          fallback={<Spinner size="sm" color={getMainColor()} />}
-        >
+    <Show when={showHiddenFolder || !isHiddenFolder()}>
+      <Box>
+        <HStack spacing="$2">
           <Show
-            when={!emptyIconVisible()}
-            fallback={<Icon color={getMainColor()} as={BiSolidFolderOpen} />}
+            when={!loading()}
+            fallback={<Spinner size="sm" color={getMainColor()} />}
           >
-            <Icon
-              color={getMainColor()}
-              as={BiSolidRightArrow}
-              transform={isOpen() ? "rotate(90deg)" : "none"}
-              transition="transform 0.2s"
-              cursor="pointer"
-              onClick={() => {
-                onToggle()
-                if (isOpen()) {
-                  load()
-                }
-              }}
-            />
+            <Show
+              when={!emptyIconVisible()}
+              fallback={<Icon color={getMainColor()} as={BiSolidFolderOpen} />}
+            >
+              <Icon
+                color={getMainColor()}
+                as={BiSolidRightArrow}
+                transform={isOpen() ? "rotate(90deg)" : "none"}
+                transition="transform 0.2s"
+                cursor="pointer"
+                onClick={() => {
+                  onToggle()
+                  if (isOpen()) {
+                    load()
+                  }
+                }}
+              />
+            </Show>
           </Show>
-        </Show>
-        <Text
-          css={{
-            // textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-          // overflow="hidden"
-          fontSize="$md"
-          cursor="pointer"
-          px="$1"
-          rounded="$md"
-          bgColor={active() ? "$info8" : "transparent"}
-          _hover={{
-            bgColor: active() ? "$info8" : hoverColor(),
-          }}
-          onClick={() => {
-            onChange(props.path)
-          }}
-        >
-          {props.path === "/" ? "root" : pathBase(props.path)}
-        </Text>
-      </HStack>
-      <Show when={isOpen()}>
-        <VStack mt="$1" pl="$4" alignItems="start" spacing="$1">
-          <For each={children()}>
-            {(item) => (
-              <Show when={showHiddenFolder || !isHide(item)}>
+          <Text
+            css={{
+              // textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+            // overflow="hidden"
+            fontSize="$md"
+            cursor="pointer"
+            px="$1"
+            rounded="$md"
+            bgColor={active() ? "$info8" : "transparent"}
+            _hover={{
+              bgColor: active() ? "$info8" : hoverColor(),
+            }}
+            onClick={() => {
+              onChange(props.path)
+            }}
+          >
+            {props.path === "/" ? "root" : pathBase(props.path)}
+          </Text>
+        </HStack>
+        <Show when={isOpen()}>
+          <VStack mt="$1" pl="$4" alignItems="start" spacing="$1">
+            <For each={children()}>
+              {(item) => (
                 <FolderTreeNode path={pathJoin(props.path, item.name)} />
-              </Show>
-            )}
-          </For>
-        </VStack>
-      </Show>
-    </Box>
+              )}
+            </For>
+          </VStack>
+        </Show>
+      </Box>
+    </Show>
   )
 }
 

--- a/src/hooks/useUtil.ts
+++ b/src/hooks/useUtil.ts
@@ -22,6 +22,15 @@ export const useUtil = () => {
       }
       return false
     },
+    isHidePath: (path: string) => {
+      const hideFiles = getHideFiles()
+      for (const reg of hideFiles) {
+        if (reg.test(path)) {
+          return true
+        }
+      }
+      return false
+    },
   }
 }
 

--- a/src/pages/home/Sidebar.tsx
+++ b/src/pages/home/Sidebar.tsx
@@ -91,6 +91,7 @@ function SidebarPannel() {
       <FolderTree
         autoOpen
         showEmptyIcon
+        showHiddenFolder={false}
         onChange={(path) => to(path)}
         handle={(handler) => setFolderTreeHandler(handler)}
       />


### PR DESCRIPTION
refer to https://github.com/alist-org/alist-web/pull/146#issuecomment-1975062111

改动如下:
- 目录树组件加了段逻辑，用来隐藏全局配置中正则匹配到的目录
- 加了个 prop `showHiddenFolder` 用来区分 `侧边栏` 和 `移动/复制` 操作里的目录树
- 通过路径栏直接访问隐藏文件夹时，侧边栏会显示该文件夹（跳出后自动隐藏）

演示效果:

https://github.com/alist-org/alist-web/assets/55272688/a2eca4ff-d689-4d52-a923-f2bad4b68803


视频中使用的正则:
```
/\/README.md/i
/\/hide_folder_and_subfolder/i
/\/only_hide_parent_folder$/i
```