### PR TITLE
Encode URL param for external player

### DIFF
--- a/src/pages/home/previews/video_box.tsx
+++ b/src/pages/home/previews/video_box.tsx
@@ -18,7 +18,7 @@ import { SelectWrapper } from "~/components"
 Artplayer.PLAYBACK_RATE = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4]
 
 export const players: { icon: string; name: string; scheme: string }[] = [
-  { icon: "iina", name: "IINA", scheme: "iina://weblink?url=$durl" },
+  { icon: "iina", name: "IINA", scheme: "iina://weblink?url=$edurl" },
   { icon: "potplayer", name: "PotPlayer", scheme: "potplayer://$durl" },
   { icon: "vlc", name: "VLC", scheme: "vlc://$durl" },
   { icon: "nplayer", name: "nPlayer", scheme: "nplayer-$durl" },


### PR DESCRIPTION
The URL passed as query parameter for IINA will be url-encoded. This will fix `Cannot open file or stream!` showing when URL contains special characters (e.g. `/[foo] bar.mkv`) for IINA.

This is somehow related to a bug in IINA [fix: avoid double percent-encode for url scheme](https://www.github.com/iina/iina/pull/4860), but I think it is better to do url-encoding in alist to support IINA until this bug has been resolved.

Additionally, if the filename contains a `%`, then it is expected to be encoded per URI standard. In this case, it is not an IINA bug.