### PR TITLE
fix: incorrect search results link with `#` (close alist-org/alist#6234)

### DIFF
--- a/src/pages/home/folder/Search.tsx
+++ b/src/pages/home/folder/Search.tsx
@@ -37,6 +37,7 @@ import { getMainColor, me, password } from "~/store"
 import { SearchNode } from "~/types"
 import {
   bus,
+  encodePath,
   fsSearch,
   getFileSize,
   handleResp,
@@ -236,7 +237,7 @@ const Search = () => {
             node.parent = "/" + node.parent
           }
         }
-        node.path = pathJoin(node.parent, node.name)
+        node.path = encodePath(pathJoin(node.parent, node.name))
       })
       setData(data)
     })


### PR DESCRIPTION
修复搜索页面的跳转链接。

触发情况:
- 文件名包含 `#` `/` `%` ` `