### PR TITLE
feat: add supports for netease music driver

### DIFF
--- a/src/lang/en/drivers.json
+++ b/src/lang/en/drivers.json
@@ -797,6 +797,11 @@
     "refresh_token": "Refresh token",
     "root_folder_path": "Root folder path"
   },
+  "NeteaseMusic": {
+    "cookie": "Cookie",
+    "song_limit": "Max number of songs when getting list",
+    "song_limit-tips": "Only get 200 songs by default"
+  },
   "config": {
     "115 Cloud": {},
     "115 Share": {},
@@ -919,6 +924,7 @@
     "WebDav": "WebDav",
     "WeiYun": "WeiYun",
     "WoPan": "WoPan",
-    "YandexDisk": "YandexDisk"
+    "YandexDisk": "YandexDisk",
+    "NeteaseMusic": "NeteaseMusic"
   }
 }

--- a/src/pages/home/previews/audio.tsx
+++ b/src/pages/home/previews/audio.tsx
@@ -6,10 +6,10 @@ import { onCleanup, onMount } from "solid-js"
 import { useLink, useRouter } from "~/hooks"
 import { getSetting, getSettingBool, objStore } from "~/store"
 import { ObjType, StoreObj } from "~/types"
-import { baseName } from "~/utils"
+import { baseName, fsGet } from "~/utils"
 
 const Preview = () => {
-  const { proxyLink, rawLink } = useLink()
+  const { proxyLink, rawLink, previewPage } = useLink()
   const { searchParams } = useRouter()
   let audios = objStore.objs.filter((obj) => obj.type === ObjType.AUDIO)
   if (audios.length === 0 || searchParams["from"] === "search") {
@@ -24,15 +24,24 @@ const Preview = () => {
     if (lrcObj) {
       lrc = proxyLink(lrcObj, true)
     }
-    return {
+    const audio = {
       name: obj.name,
       artist: "Unknown",
       url: rawLink(obj, true),
       cover:
+        obj.thumb ||
         getSetting("audio_cover") ||
         "https://jsd.nn.ci/gh/alist-org/logo@main/logo.svg",
       lrc: lrc,
     }
+    if (objStore.provider === "NeteaseMusic") {
+      const matched = obj.name.match(/((.+)\s-\s)?(.+)\.(mp3|flac)/)
+      audio.artist = matched?.[2] || "Unknown"
+      audio.name = matched?.[3] || obj.name
+      const lrcURL = new URL(previewPage(obj).replace(/\.(mp3|flac)/, ".lrc"))
+      audio.lrc = decodeURIComponent(lrcURL.pathname)
+    }
+    return audio
   }
   onMount(() => {
     ap = new APlayer({
@@ -45,9 +54,24 @@ const Preview = () => {
       volume: 0.7,
       mutex: true,
       listFolded: false,
-      lrcType: 3,
+      lrcType: objStore.provider === "NeteaseMusic" ? 1 : 3,
       audio: audios.map(objToAudio),
     })
+    if (objStore.provider === "NeteaseMusic") {
+      ap.on("loadstart", () => {
+        const i = ap.list.index
+        if (!ap.list.audios[i].lrc) return
+        const lrcURL = ap.list.audios[i].lrc
+        fsGet(lrcURL).then((resp) => {
+          ap.lrc.async = true
+          ap.lrc.parsed[i] = undefined
+          ap.list.audios[i].lrc = resp.data.raw_url
+          ap.lrc.switch(i) // fetch lrc into `parsed`
+          ap.list.audios[i].lrc = ""
+          ap.lrc.async = false
+        })
+      })
+    }
     const curIndex = audios.findIndex((obj) => obj.name === objStore.obj.name)
     if (curIndex !== -1) {
       ap.list.switch(curIndex)


### PR DESCRIPTION
Related to https://github.com/alist-org/alist/pull/6423

改动如下:
- 兼容驱动
- 获取可显示的封面
- 获取并显示可用的歌词