### PR TITLE
fix: base path for relative path in markdown

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -12,12 +12,12 @@ import { Anchor, Box, List, ListItem } from "@hope-ui/solid"
 import { useParseText, useRouter } from "~/hooks"
 import { EncodingSelect } from "."
 import once from "just-once"
-import { pathDir, pathJoin, api } from "~/utils"
+import { pathDir, pathJoin, api, pathResolve } from "~/utils"
 import { createStorageSignal } from "@solid-primitives/storage"
 import { isMobile } from "~/utils/compatibility.js"
 import { useScrollListener } from "~/pages/home/toolbar/BackTop.jsx"
 import { Motion } from "@motionone/solid"
-import { getMainColor } from "~/store"
+import { getMainColor, me } from "~/store"
 
 type TocItem = { indent: number; text: string; tagName: string; key: string }
 
@@ -194,10 +194,9 @@ export function Markdown(props: {
       if (url.startsWith("/")) {
         url = `${api}/d${url}`
       } else {
-        url = url.replace("./", "")
         url = `${api}/d${pathJoin(
-          props.readme ? pathname() : pathDir(pathname()),
-          url,
+          me().base_path,
+          pathResolve(props.readme ? pathname() : pathDir(pathname()), url),
         )}`
       }
       const ans = `![${name}](${url})`

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -13,6 +13,10 @@ export const standardizePath = (path: string, noRootSlash?: boolean) => {
   return path
 }
 
+export const pathResolve = (...paths: string[]) => {
+  return new URL(pathJoin(...paths), location.origin).pathname
+}
+
 export const pathJoin = (...paths: string[]) => {
   return paths.join("/").replace(/\/{2,}/g, "/")
 }


### PR DESCRIPTION
fix https://github.com/alist-org/alist/issues/6419

改动如下
- Markdown 预览组件 解析 相对路径 时 加上 `base_path`
- 新增 `pathResolve` 工具函数，将类似 `./a` `../a` `a/../b` 的路径转成绝对路径