### PR TITLE
fix: show last selected folder on copy/move modal

### DIFF
--- a/src/components/FolderTree.tsx
+++ b/src/components/FolderTree.tsx
@@ -195,7 +195,12 @@ export type ModalFolderChooseProps = {
 }
 export const ModalFolderChoose = (props: ModalFolderChooseProps) => {
   const t = useT()
-  const [value, setValue] = createSignal(props.defaultValue ?? "")
+  const [value, setValue] = createSignal(props.defaultValue ?? "/")
+  const [handler, setHandler] = createSignal<FolderTreeHandler>()
+  createEffect(() => {
+    if (!props.opened) return
+    handler()?.setPath(value())
+  })
   return (
     <Modal
       size="xl"
@@ -208,7 +213,11 @@ export const ModalFolderChoose = (props: ModalFolderChooseProps) => {
         {/* <ModalCloseButton /> */}
         <ModalHeader>{t("home.toolbar.choose_dst_folder")}</ModalHeader>
         <ModalBody>
-          <FolderTree onChange={setValue} />
+          <FolderTree
+            onChange={setValue}
+            handle={(h) => setHandler(h)}
+            autoOpen
+          />
         </ModalBody>
         <ModalFooter display="flex" gap="$2">
           <Button onClick={props.onClose} colorScheme="neutral">


### PR DESCRIPTION
fix https://github.com/alist-org/alist/issues/6428

refer to https://github.com/alist-org/alist/issues/6428#issuecomment-2107176544

改动如下:
- `复制` `移动` `聚合移动` 的弹窗组件 `ModalFolderChoose` 正确显示 并 展开到 已选择的文件夹

https://github.com/alist-org/alist-web/assets/55272688/8a64570b-9d7a-49b2-a274-2bc7130f0962

