### PR TITLE
style: Search Box

### DIFF
--- a/src/pages/home/header/Header.tsx
+++ b/src/pages/home/header/Header.tsx
@@ -57,7 +57,7 @@ export const Header = () => {
             <Show when={objStore.state === State.Folder}>
               <Show when={getSetting("search_index") !== "none"}>
                 <HStack
-                  // bg="$neutral4"
+                  bg="$neutral4"
                   w="$32"
                   p="$1"
                   rounded="$md"

--- a/src/pages/home/header/Header.tsx
+++ b/src/pages/home/header/Header.tsx
@@ -7,8 +7,9 @@ import {
   Kbd,
   CenterProps,
 } from "@hope-ui/solid"
+import { changeColor } from "seemly"
 import { Show, createMemo } from "solid-js"
-import { getSetting, local, objStore, State } from "~/store"
+import { getMainColor, getSetting, local, objStore, State } from "~/store"
 import { BsSearch } from "solid-icons/bs"
 import { CenterLoading } from "~/components"
 import { Container } from "../Container"
@@ -56,15 +57,17 @@ export const Header = () => {
             <Show when={objStore.state === State.Folder}>
               <Show when={getSetting("search_index") !== "none"}>
                 <HStack
-                  bg="$neutral4"
+                  // bg="$neutral4"
                   w="$32"
-                  p="$2"
+                  p="$1"
                   rounded="$md"
                   justifyContent="space-between"
                   border="2px solid transparent"
                   cursor="pointer"
+                  color={getMainColor()}
+                  bgColor={changeColor(getMainColor(), { alpha: 0.15 })}
                   _hover={{
-                    borderColor: "$info6",
+                    bgColor: changeColor(getMainColor(), { alpha: 0.2 }),
                   }}
                   onClick={() => {
                     bus.emit("tool", "search")


### PR DESCRIPTION
将搜索框对 背景/颜色 大小 与右侧按钮进行统一

![image](https://github.com/alist-org/alist-web/assets/56105412/137bd52a-3dcd-4ba6-9884-cb89f9382910)
- 左侧为修改后，右侧为修改前
