### PR TITLE
修复iOS14若干问题

### DIFF
--- a/src/app/index.css
+++ b/src/app/index.css
@@ -44,3 +44,7 @@
 .hope-ui-dark ::-webkit-scrollbar-thumb:vertical:active {
   background-color: rgb(58, 58, 58);
 }
+
+.hope-select__option {
+  flex-shrink: 0;
+}

--- a/src/pages/manage/storages/Item.tsx
+++ b/src/pages/manage/storages/Item.tsx
@@ -65,7 +65,7 @@ const Item = (props: ItemProps) => {
             type={props.name == "password" ? "password" : "text"}
             readOnly={props.readonly}
             value={props.value as string}
-            onInput={
+            onChange={
               props.type === Type.String
                 ? (e) => props.onChange?.(e.currentTarget.value)
                 : undefined


### PR DESCRIPTION
1. iOS 14 DropDown下拉选项高度丢失，添加`flex-shrink: 0`后解决
![telegram-cloud-photo-size-5-6066751553571764945-y](https://github.com/user-attachments/assets/f198c68a-b7bc-4081-a1a6-609380305eb2)

3. iOS 14.8 输入法导致输入内容重复

https://github.com/user-attachments/assets/41bd365a-6846-4d19-a5ee-1237ae26db13

