### PR TITLE
fix(video): use raw URLs for video player schemes, as they might not support 302 redirection

### DIFF
--- a/src/pages/home/previews/video_box.tsx
+++ b/src/pages/home/previews/video_box.tsx
@@ -18,46 +18,46 @@ import { SelectWrapper } from "~/components"
 Artplayer.PLAYBACK_RATE = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4]
 
 export const players: { icon: string; name: string; scheme: string }[] = [
-  { icon: "iina", name: "IINA", scheme: "iina://weblink?url=$edurl" },
-  { icon: "potplayer", name: "PotPlayer", scheme: "potplayer://$durl" },
-  { icon: "vlc", name: "VLC", scheme: "vlc://$durl" },
-  { icon: "nplayer", name: "nPlayer", scheme: "nplayer-$durl" },
+  { icon: "iina", name: "IINA", scheme: "iina://weblink?url=$eurl" },
+  { icon: "potplayer", name: "PotPlayer", scheme: "potplayer://$url" },
+  { icon: "vlc", name: "VLC", scheme: "vlc://$url" },
+  { icon: "nplayer", name: "nPlayer", scheme: "nplayer-$url" },
   {
     icon: "omniplayer",
     name: "OmniPlayer",
-    scheme: "omniplayer://weblink?url=$durl",
+    scheme: "omniplayer://weblink?url=$url",
   },
   {
     icon: "figplayer",
     name: "Fig Player",
-    scheme: "figplayer://weblink?url=$durl",
+    scheme: "figplayer://weblink?url=$url",
   },
   {
     icon: "infuse",
     name: "Infuse",
-    scheme: "infuse://x-callback-url/play?url=$durl",
+    scheme: "infuse://x-callback-url/play?url=$url",
   },
   {
     icon: "fileball",
     name: "Fileball",
-    scheme: "filebox://play?url=$durl",
+    scheme: "filebox://play?url=$url",
   },
   {
     icon: "mxplayer",
     name: "MX Player",
     scheme:
-      "intent:$durl#Intent;package=com.mxtech.videoplayer.ad;S.title=$name;end",
+      "intent:$url#Intent;package=com.mxtech.videoplayer.ad;S.title=$name;end",
   },
   {
     icon: "mxplayer-pro",
     name: "MX Player Pro",
     scheme:
-      "intent:$durl#Intent;package=com.mxtech.videoplayer.pro;S.title=$name;end",
+      "intent:$url#Intent;package=com.mxtech.videoplayer.pro;S.title=$name;end",
   },
   {
     icon: "iPlay",
     name: "iPlay",
-    scheme: "iplay://play/any?type=url&url=$bdurl",
+    scheme: "iplay://play/any?type=url&url=$burl",
   },
 ]
 


### PR DESCRIPTION
Use raw URLs for video player schemes, as they might not support 302 redirection (Like IINA).
外部播放器跳转链接使用原始地址，因为外部播放器可能不支持 302 跳转（比如 IINA）。