### PR TITLE
perf(markdown): optimize large file handling

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -265,7 +265,7 @@ export function Markdown(props: {
       setTimeout(() => {
         setShow(true)
         runHighlight && hljs.highlightAll()
-        window.onMDRender && window.onMDRender()
+        window.onMDRender && window.onMDRender(content)
       })
     }),
   )

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -160,13 +160,6 @@ const insertKatexCSS = once(() => {
   document.head.appendChild(link)
 })
 
-const insertMermaidJS = once(() => {
-  const script = document.createElement("script")
-  script.src =
-    "https://registry.npmmirror.com/mermaid/11/files/dist/mermaid.min.js"
-  document.body.appendChild(script)
-})
-
 export function Markdown(props: {
   children?: string | ArrayBuffer
   class?: string
@@ -231,14 +224,9 @@ export function Markdown(props: {
         setRemarkPlugins([...remarkPlugins(), reMarkMath])
         setRehypePlugins([...rehypePlugins(), rehypeKatex])
       }
-      insertMermaidJS()
       setTimeout(() => {
         setShow(true)
         hljs.highlightAll()
-        window.mermaid &&
-          window.mermaid.run({
-            querySelector: ".language-mermaid",
-          })
         window.onMDRender && window.onMDRender()
       })
     }),

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -252,10 +252,10 @@ export function Markdown(props: {
     runHighlight = false
   }
   createEffect(
-    on(md, async () => {
+    on(md, async (content) => {
       setShow(false)
       // lazy for math rendering
-      if (/\$\$[\s\S]+?\$\$|\$[^$\n]+?\$/.test(md())) {
+      if (/\$\$[\s\S]+?\$\$|\$[^$\n]+?\$/.test(content)) {
         const { default: reMarkMath } = await import("remark-math")
         const { default: rehypeKatex } = await import("rehype-katex")
         insertKatexCSS()

--- a/src/lang/en/home.json
+++ b/src/lang/en/home.json
@@ -14,7 +14,10 @@
     "tr-install": "TrollStore",
     "tr-installing": "TrollStore Installing",
     "open_in_new_window": "Open in new window",
-    "auto_next": "Auto next"
+    "auto_next": "Auto next",
+    "large_file": "File is too large to preview.",
+    "large_file_desc": "This file may not be in text format and exceeds preview size limits. It's recommended to Download or use Text Editor.",
+    "large_file_hljs_disabled": "Highlighting is disabled for large content to optimize performance. Please use Text Editor instead."
   },
   "layouts": {
     "list": "List View",


### PR DESCRIPTION
- 优化 Markdown 预览器性能
  - 当文件大于 256 KB 时禁用代码高亮，避免造成浏览器卡死
  - 当文件大于 2 MB 时禁用 Markdown 预览，并增加警告
  - Close: https://github.com/AlistGo/alist/issues/8435

- 撤销 PR #214 中引入的 Mermaid 支持功能，防止全局加载 Mermaid JS 脚本，减少对 npmmirror 流量的不必要消耗
  - 可通过设置->全局->自定义中定义函数 `onMDRender` 引入
  - 为 onMDRender 函数增加 Markdown 内容传参，方便获取内容
  - 减少 md() 执行次数
