### PR TITLE
fix(download): support full directory traversal when sending to Aria2

### DIFF
--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -3,6 +3,7 @@ import { local, password, selectedObjs as _selectedObjs } from "~/store"
 import { fsList, notify, pathBase, pathJoin } from "~/utils"
 import { getLinkByDirAndObj, useRouter, useT } from "~/hooks"
 import { useSelectedLink } from "~/hooks"
+import { getPagination } from "~/store/settings"
 import { Obj } from "~/types"
 
 interface File {
@@ -69,24 +70,35 @@ export const useDownload = () => {
             },
           ]
         } else {
-          const resp = await fsList(
-            pathJoin(pathname(), pre, obj.name),
-            password(),
-          )
-          if (resp.code !== 200) {
-            return resp.message
-          }
           const res: File[] = []
-          for (const _obj of resp.data.content ?? []) {
-            const _res = await fetchFolderStructure(
-              pathJoin(pre, obj.name),
-              _obj,
+          let page = 1
+          const perPage = getPagination().size
+          while (true) {
+            const resp = await fsList(
+              pathJoin(pathname(), pre, obj.name),
+              password(),
+              page,
+              perPage,
             )
-            if (typeof _res === "string") {
-              return _res
-            } else {
-              res.push(..._res)
+            if (resp.code !== 200) {
+              return resp.message
             }
+            const content = resp.data.content ?? []
+            for (const _obj of content) {
+              const _res = await fetchFolderStructure(
+                pathJoin(pre, obj.name),
+                _obj,
+              )
+              if (typeof _res === "string") {
+                return _res
+              } else {
+                res.push(..._res)
+              }
+            }
+            if (content.length < perPage) {
+              break
+            }
+            page++
           }
           return res
         }


### PR DESCRIPTION
Description
### The Problem
Currently, when a user selects a directory and clicks **"Send To Aria2"**, Alist only adds the first page of files (default 50) to the Aria2 download queue. Any files beyond the first page are ignored, requiring users to manually add the remaining files, which is inconvenient for large directories.

This occurs because the `fetchFolderStructure` function in `useDownload.ts` calls the `fsList` API without handling pagination, thus only receiving the first response payload.

### The Solution
1.  **Pagination Loop**: Modified `fetchFolderStructure` to include a `while` loop that continues to request the next page of the directory content until all files and sub-directories are retrieved.
2.  **Settings Integration**: Replaced the hardcoded page size with `getPagination().size` from the settings store. This ensures the "Send To Aria2" functionality respects the `default_page_size` configured in the Admin settings and adheres to the system's `MAX_PAGE_SIZE` limit.

---

## Steps to Reproduce
1. Create or use a directory containing more than 50 files.
2. Right-click the directory $\rightarrow$ **Download** $\rightarrow$ **Send to Aria2**.
3. Check the Aria2 RPC client (e.g., AriaNg).
4. **Observed Result**: Only the first 50 files appear in the queue.
5. **Expected Result**: All files within the directory (and its sub-directories) should be added to the queue.

---

## Implementation Details
- **File modified**: `src/hooks/useDownload.ts`
- **Logic change**: 
    - Introduced a `page` counter and a `while` loop inside `fetchFolderStructure`.
    - Added a break condition: `if (content.length < perPage) break;`.
    - Integrated `getPagination()` from `~/store/settings` to determine `perPage`.

---

## Verification & Test Plan

### ✅ Manual Testing
- [x] **Large Directory Test**: Selected a folder with 120 files $\rightarrow$ Verified all 120 files were sent to Aria2.
- [x] **Recursive Directory Test**: Selected a nested folder structure $\rightarrow$ Verified all files in all sub-folders were retrieved.
- [x] **Admin Setting Sync**: Changed `default_page_size` in Admin settings $\rightarrow$ Verified the `fs/list` request's `per_page` parameter updated accordingly.

### ✅ Technical Verification
- [x] **Network Inspection**: Verified via Browser DevTools $\rightarrow$ Network Tab that multiple `fs/list` requests are triggered with incrementing `page` parameters (`page=1`, `page=2`, etc.) until the full list is fetched.
- [x] **Boundary Test**: Verified that the loop terminates correctly when the total number of files is exactly a multiple of the page size.