### PR TITLE
Gate remembered sorting by server setting

### DIFF
--- a/src/lang/en/drivers.json
+++ b/src/lang/en/drivers.json
@@ -712,7 +712,14 @@
     "device_id": "Device id",
     "device_id-tips": "Optional custom device id (32 hex chars), auto-generated when empty",
     "order_by": "Order by",
-    "order_by-tips": "0:name,1:size,2:create_time,3:update_time",
+    "order_by-tips": "Sort field used by the file list",
+    "order_bys": {
+      "0": "Name",
+      "1": "Size",
+      "2": "Created time",
+      "3": "Updated time",
+      "4": "File type"
+    },
     "page_size": "Page size",
     "phone_number": "Phone number",
     "phone_number-tips": "Phone number for SMS login, e.g. +86 13800000000",
@@ -721,8 +728,12 @@
     "root_folder_id": "Root folder id",
     "send_code": "Send code",
     "send_code-tips": "Set true and save to send SMS code, it auto-resets to false after sending",
-    "sort_type": "Sort type",
-    "sort_type-tips": "0:asc,1:desc",
+    "sort_type": "Order direction",
+    "sort_type-tips": "Sort direction used by the file list",
+    "sort_types": {
+      "0": "Ascending",
+      "1": "Descending"
+    },
     "verification_id": "Verification id",
     "verification_id-tips": "Auto-generated after sending SMS code; do not edit manually",
     "verify_code": "Verify code",

--- a/src/lang/en/settings.json
+++ b/src/lang/en/settings.json
@@ -27,6 +27,8 @@
   "filename_char_mapping": "Filename char mapping",
   "filter_readme_scripts": "Filter readme scripts",
   "forward_direct_link_params": "Forward direct link params",
+  "frontend_remember_sort": "Remember frontend sorting",
+  "frontend_remember_sort-tips": "Persist frontend list sorting in the browser. When disabled, backend or driver order is used until the user sorts manually in the current session.",
   "frp_auth_token": "Frp auth token",
   "frp_custom_domain": "Frp custom domain",
   "frp_enabled": "Frp enabled",

--- a/src/pages/manage/storages/Item.tsx
+++ b/src/pages/manage/storages/Item.tsx
@@ -146,6 +146,34 @@ const Item = (props: ItemProps) => {
             }
           />
         </Match>
+        <Match when={props.type === Type.Number && props.options}>
+          <Select
+            id={props.name}
+            readOnly={props.readonly}
+            defaultValue={String(props.value)}
+            onChange={
+              props.type === Type.Number
+                ? (value) => {
+                    const parsed = parseInt(value, 10)
+                    props.onChange?.(Number.isNaN(parsed) ? 0 : parsed)
+                  }
+                : undefined
+            }
+          >
+            <SelectOptions
+              readonly={props.readonly}
+              options={props.options.split(",").map((key) => ({
+                key,
+                label: t(
+                  (props.options_prefix ??
+                    (props.driver === "common"
+                      ? `storages.common.${props.name}s`
+                      : `drivers.${props.driver}.${props.name}s`)) + `.${key}`,
+                ),
+              }))}
+            />
+          </Select>
+        </Match>
         <Match when={props.type === Type.Number}>
           <Show
             when={isChunkSizeField}

--- a/src/store/obj.ts
+++ b/src/store/obj.ts
@@ -6,6 +6,7 @@ import { Obj, StoreObj } from "~/types"
 import { bus, log, trimBase } from "~/utils"
 import { keyPressed } from "./key-event"
 import { local } from "./local_settings"
+import { getSettingBool } from "./settings"
 
 export enum State {
   Initial, // Initial state
@@ -204,6 +205,7 @@ const layoutRecord: Record<string, LayoutType> = (() => {
   }
 })()
 type SortPreference = { orderBy: OrderBy; reverse: boolean }
+const activeSortRecord: Record<string, SortPreference> = {}
 const sortRecord: Record<string, SortPreference> = (() => {
   try {
     return JSON.parse(localStorage.getItem("sortRecord") || "{}")
@@ -212,6 +214,8 @@ const sortRecord: Record<string, SortPreference> = (() => {
   }
 })()
 const globalSortRecordKey = "globalSortPreference"
+const isFrontendRememberSortEnabled = () =>
+  getSettingBool("frontend_remember_sort")
 const getGlobalSortPreference = (): SortPreference | undefined => {
   try {
     const preference = JSON.parse(
@@ -249,11 +253,19 @@ export const getSortPreference = (
   path = getCurrentPath(),
 ): { orderBy: OrderBy; reverse: boolean } | undefined => {
   const normalizedPath = normalizeSortPath(path)
-  const preference = sortRecord[normalizedPath]
+  const preference = activeSortRecord[normalizedPath]
   if (preference && isValidOrderBy(preference.orderBy)) {
     return {
       orderBy: preference.orderBy,
       reverse: !!preference.reverse,
+    }
+  }
+  if (!isFrontendRememberSortEnabled()) return undefined
+  const storedPreference = sortRecord[normalizedPath]
+  if (storedPreference && isValidOrderBy(storedPreference.orderBy)) {
+    return {
+      orderBy: storedPreference.orderBy,
+      reverse: !!storedPreference.reverse,
     }
   }
   return getGlobalSortPreference()
@@ -265,6 +277,11 @@ export const setSortPreference = (
   path = getCurrentPath(),
 ) => {
   const normalizedPath = normalizeSortPath(path)
+  activeSortRecord[normalizedPath] = {
+    orderBy,
+    reverse,
+  }
+  if (!isFrontendRememberSortEnabled()) return
   sortRecord[normalizedPath] = {
     orderBy,
     reverse,


### PR DESCRIPTION
## Summary
- restore frontend remembered sorting behind the new server setting
- keep manual column sorting active for the current session when remembering is disabled
- render numeric storage options as select controls with readable labels
- add readable GuangYaPan sorting labels

## Testing
- pnpm -s build
- lint-staged prettier ran during commits

Related to AlistGo/alist#9491
Companion backend PR: AlistGo/alist#9503