### PR TITLE
feat: add GuangYaPan offline download settings

### DIFF
--- a/src/lang/en/settings.json
+++ b/src/lang/en/settings.json
@@ -1,4 +1,5 @@
 {
+  "115_temp_dir": "115 temp dir",
   "allow_indexed": "Allow indexed",
   "allow_mounted": "Allow mounted",
   "allow_register": "Allow register",
@@ -56,6 +57,7 @@
   "ftp_public_host": "Ftp public host",
   "ftp_tls_private_key_path": "Ftp tls private key path",
   "ftp_tls_public_cert_path": "Ftp tls public cert path",
+  "guangyapan_temp_dir": "GuangYaPan temp dir",
   "hide_files": "Hide files",
   "home_container": "Home container",
   "home_containers": {
@@ -99,6 +101,7 @@
     "load_more": "Load more",
     "pagination": "Pagination"
   },
+  "pikpak_temp_dir": "PikPak temp dir",
   "preview_archives_by_default": "Preview archives by default",
   "privacy_regs": "Privacy regs",
   "proxy_ignore_headers": "Proxy ignore headers",
@@ -150,6 +153,7 @@
   "text_types": "Text types",
   "thumbnail_size": "Thumbnail size",
   "thumbnail_size-tips": "Thumbnail width in pixels. Height is scaled proportionally.",
+  "thunder_temp_dir": "Thunder temp dir",
   "token": "Token",
   "transmission_seedtime": "Transmission seedtime",
   "transmission_uri": "Transmission uri",

--- a/src/lang/en/settings_other.json
+++ b/src/lang/en/settings_other.json
@@ -18,6 +18,8 @@
   "set_pikpak": "Set PikPak",
   "thunder": "Thunder",
   "set_thunder": "Set Thunder",
+  "guangyapan": "GuangYaPan",
+  "set_guangyapan": "Set GuangYaPan",
   "frp": "FRP Intranet Tunnel",
   "frp_save_apply": "Save & Apply",
   "frp_stop": "Stop FRP",

--- a/src/pages/manage/settings/Other.tsx
+++ b/src/pages/manage/settings/Other.tsx
@@ -26,6 +26,7 @@ const OtherSettings = () => {
   const [pan115TempDir, set115TempDir] = createSignal("")
   const [pikpakTempDir, setPikPakTempDir] = createSignal("")
   const [thunderTempDir, setThunderTempDir] = createSignal("")
+  const [guangYaPanTempDir, setGuangYaPanTempDir] = createSignal("")
   const [token, setToken] = createSignal("")
   const [settings, setSettings] = createSignal<SettingItem[]>([])
   const [settingsLoading, settingsData] = useFetch(
@@ -68,6 +69,12 @@ const OtherSettings = () => {
         temp_dir: thunderTempDir(),
       }),
   )
+  const [setGuangYaPanLoading, setGuangYaPan] = useFetch(
+    (): PResp<string> =>
+      r.post("/admin/setting/set_guangyapan", {
+        temp_dir: guangYaPanTempDir(),
+      }),
+  )
   const [setTokenLoading, setTokenRequest] = useFetch(
     (): PResp<string> => r.post("/admin/setting/set_token", { token: token() }),
   )
@@ -93,6 +100,9 @@ const OtherSettings = () => {
       )
       setThunderTempDir(
         data.find((i) => i.key === "thunder_temp_dir")?.value || "",
+      )
+      setGuangYaPanTempDir(
+        data.find((i) => i.key === "guangyapan_temp_dir")?.value || "",
       )
       setSettings(data)
     })
@@ -248,6 +258,29 @@ const OtherSettings = () => {
         }}
       >
         {t("settings_other.set_thunder")}
+      </Button>
+      <Heading my="$2">{t("settings_other.guangyapan")}</Heading>
+      <FormControl w="$full" display="flex" flexDirection="column">
+        <FormLabel for="guangyapan_temp_dir" display="flex" alignItems="center">
+          {t(`settings.guangyapan_temp_dir`)}
+        </FormLabel>
+        <FolderChooseInput
+          id="guangyapan_temp_dir"
+          value={guangYaPanTempDir()}
+          onChange={(path) => setGuangYaPanTempDir(path)}
+        />
+      </FormControl>
+      <Button
+        my="$2"
+        loading={setGuangYaPanLoading()}
+        onClick={async () => {
+          const resp = await setGuangYaPan()
+          handleResp(resp, (data) => {
+            notify.success(data)
+          })
+        }}
+      >
+        {t("settings_other.set_guangyapan")}
       </Button>
       <Heading my="$2">{t("settings.token")}</Heading>
       <Input


### PR DESCRIPTION
## Summary
- add GuangYaPan temp-dir setting to the Other settings page
- add i18n labels for GuangYaPan and the existing cloud offline temp-dir fields
- wire the UI to /admin/setting/set_guangyapan

## Related
- Backend PR: https://github.com/AlistGo/alist/pull/9505

## Verification
- pnpm build
