### PR TITLE
fix: respect all pagination mode

### DIFF
--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -71,6 +71,9 @@ export const usePath = () => {
   }
 
   const clampPerPage = (size?: number) => {
+    if (pagination.type === "all") {
+      return -1
+    }
     const querySize = perPageFromQuery()
     const raw =
       typeof size === "number" && Number.isFinite(size)

--- a/src/pages/home/Obj.tsx
+++ b/src/pages/home/Obj.tsx
@@ -41,6 +41,9 @@ export const Obj = () => {
       : undefined
   })
   const perPage = createMemo(() => {
+    if (pagination.type === "all") {
+      return -1
+    }
     return pagination.type === "pagination"
       ? parseInt(searchParams["per_page"], 10) || pagination.size
       : undefined

--- a/src/pages/share/index.tsx
+++ b/src/pages/share/index.tsx
@@ -708,10 +708,16 @@ const SharePage = () => {
   const currentToken = createMemo(() => shareToken())
   const pagination = getPagination()
   const currentPage = createMemo(() => {
+    if (pagination.type === "all") {
+      return 1
+    }
     const value = parseInt(searchParams["page"], 10)
     return Number.isFinite(value) && value > 0 ? value : 1
   })
   const currentPerPage = createMemo(() => {
+    if (pagination.type === "all") {
+      return -1
+    }
     const value = parseInt(searchParams["per_page"], 10)
     if (Number.isFinite(value) && value > 0) {
       return Math.min(MAX_PAGE_SIZE, value)
@@ -1307,7 +1313,8 @@ const SharePage = () => {
                   objStore.state === State.Folder &&
                   !nodeLoading() &&
                   !infoLoading() &&
-                  !nodeError()
+                  !nodeError() &&
+                  pagination.type !== "all"
                 }
               >
                 <SharePager

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -98,8 +98,7 @@ export const getPagination = (): {
     Math.max(1, getSettingNumber("default_page_size", DEFAULT_PAGE_SIZE)),
   )
   return {
-    // `all` would trigger very large payloads; fallback to pagination.
-    type: rawType === "all" ? "pagination" : rawType,
+    type: rawType,
     size,
   }
 }


### PR DESCRIPTION
## Summary
- keep the site pagination type as `all` instead of falling back to pagination
- request `per_page=-1` for ALL mode on home and share folder lists
- hide the share pagination controls in ALL mode

## Tests
- `pnpm build`

Backend PR: https://github.com/AlistGo/alist/pull/9512