### PR TITLE
fix(share): use virtual path for share, not obj.path

### DIFF
--- a/src/pages/home/folder/context-menu.tsx
+++ b/src/pages/home/folder/context-menu.tsx
@@ -224,12 +224,8 @@ export const ContextMenu = () => {
         <Show when={oneChecked()}>
           <Item
             onClick={({ props }) => {
-              const targetPath =
-                props.path && props.path.startsWith("/")
-                  ? props.path
-                  : pathJoin(getCurrentPath(), props.name)
               bus.emit("share", {
-                path: targetPath,
+                path: pathJoin(getCurrentPath(), props.name),
                 name: props.name,
                 is_dir: props.is_dir,
               })


### PR DESCRIPTION
## Problem
Share via the file context menu fails when the underlying storage is a Local driver whose `root_folder_path` differs from its alist mount path (common on Termux / Android setups). The user gets:

```
failed get storage: storage not found; rawPath:/data/data/com.termux/files/home/storage/download/foo.tar.gz
```

PC users sharing from cloud drivers were unaffected — hence the symptom "PC right-click works, mobile long-press fails".

## Root cause
`src/pages/home/folder/context-menu.tsx` preferred `props.path` (the API's `obj.path` field) over `pathJoin(getCurrentPath(), props.name)`:

```ts
const targetPath =
  props.path && props.path.startsWith("/")
    ? props.path
    : pathJoin(getCurrentPath(), props.name)
```

For the Local driver, `obj.Path` is the physical disk path set in `drivers/local/driver.go` (`Path: filePath`). Cloud drivers (Quark / Baidu / 115 / …) don't populate `obj.Path`, so the response field is empty and the fallback branch (correct) was used instead.

The `ListItem.tsx` helper `getFullPath()` already handles this correctly by always using `pathJoin(pathname(), props.obj.name)`; the share Item was inconsistent.

## Fix
Always build the share target with `pathJoin(getCurrentPath(), props.name)`, matching `getFullPath()`.

## Verification
Reproduced end-to-end against an isolated alist server with a Local storage where `mount_path=/src` and `root_folder_path=/tmp/alist-test/src`:

- Old (physical) path → `code:500 failed get storage: storage not found; rawPath:/tmp/...`
- New (virtual) path → `code:200 success, share_id:0INyiLZs`

## Companion
Workaround for the symptom. The deeper fix — normalising the backend's `obj.path` field semantics — is being tracked separately on the alist repo.