### PR TITLE
feat(strm): one-click STRM generate button, progress dialog + task center

### DIFF
--- a/src/lang/en/global.json
+++ b/src/lang/en/global.json
@@ -37,5 +37,7 @@
   "generate_strm_start": "Generation started",
   "generate_strm_progress": "Generating Strm...",
   "generate_strm_done": "Strm generated",
-  "generate_strm_failed": "Generation failed"
+  "generate_strm_failed": "Generation failed",
+  "generate_strm_hide": "Hide",
+  "generate_strm_background": "The task keeps running in the background. Track it in the task center."
 }

--- a/src/lang/en/global.json
+++ b/src/lang/en/global.json
@@ -32,5 +32,10 @@
   "name": "Name",
   "refresh_success": "Refresh successfully",
   "refresh_failed": "Refresh failed",
-  "required": "required"
+  "required": "required",
+  "generate_strm": "Generate Strm",
+  "generate_strm_start": "Generation started",
+  "generate_strm_progress": "Generating Strm...",
+  "generate_strm_done": "Strm generated",
+  "generate_strm_failed": "Generation failed"
 }

--- a/src/lang/en/home.json
+++ b/src/lang/en/home.json
@@ -158,6 +158,7 @@
     "new_file": "New File",
     "input_filename": "Input filename",
     "cancel_select": "Cancel Select",
+    "generate_strm": "Generate Strm",
     "offline_download": "Offline download",
     "offline_download-tips": "One URL per line",
     "delete_policy": {

--- a/src/lang/en/manage.json
+++ b/src/lang/en/manage.json
@@ -26,6 +26,7 @@
     "permissions_config": "Config",
     "upload": "Upload",
     "copy": "Copy",
+    "strm_generate": "Strm Generate",
     "decompress": "Decompress",
     "s3_transition": "S3 Transition",
     "backup-restore": "Backup & Restore",

--- a/src/lang/en/tasks.json
+++ b/src/lang/en/tasks.json
@@ -3,6 +3,7 @@
   "offline_download_transfer": "Transfer downloaded file to corresponding storage",
   "upload": "Upload file to corresponding storage",
   "copy": "Copy file from a storage to another storage",
+  "strm_generate": "Generate local .strm files for a Strm storage",
   "decompress": "Download and decompress an archive file",
   "decompress_upload": "Upload extracted file into target storage",
   "s3_transition": "Archive and restore S3 objects",
@@ -43,6 +44,9 @@
       "dst": "Destination Path"
     },
     "upload": {
+      "path": "Path"
+    },
+    "strm_generate": {
       "path": "Path"
     },
     "offline_download": {

--- a/src/pages/home/toolbar/Right.tsx
+++ b/src/pages/home/toolbar/Right.tsx
@@ -13,6 +13,7 @@ import { usePath } from "~/hooks"
 import { Motion } from "@motionone/solid"
 import { isTocVisible, setTocDisabled } from "~/components"
 import { BiSolidBookContent } from "solid-icons/bi"
+import { ToolbarStrmGenerate } from "./StrmGenerate"
 
 export const Right = () => {
   const { isOpen, onToggle } = createDisclosure({
@@ -122,6 +123,7 @@ export const Right = () => {
                 }}
               />
             </Show>
+            <ToolbarStrmGenerate />
             <Show when={isTocVisible()}>
               <RightIcon
                 as={BiSolidBookContent}

--- a/src/pages/home/toolbar/StrmGenerate.tsx
+++ b/src/pages/home/toolbar/StrmGenerate.tsx
@@ -1,0 +1,15 @@
+import { Show } from "solid-js"
+import { useRouter } from "~/hooks"
+import { me, objStore } from "~/store"
+import { StrmGenerateButton } from "~/pages/manage/storages/StrmGenerate"
+
+export const ToolbarStrmGenerate = () => {
+  const { pathname } = useRouter()
+  const isAdmin = () => (me().role || []).includes(2)
+  const isStrm = () => objStore.provider === "Strm"
+  return (
+    <Show when={isAdmin() && isStrm()}>
+      <StrmGenerateButton path={pathname()} />
+    </Show>
+  )
+}

--- a/src/pages/home/toolbar/StrmGenerate.tsx
+++ b/src/pages/home/toolbar/StrmGenerate.tsx
@@ -1,7 +1,9 @@
 import { Show } from "solid-js"
+import { TbFileExport } from "solid-icons/tb"
 import { useRouter } from "~/hooks"
 import { me, objStore } from "~/store"
-import { StrmGenerateButton } from "~/pages/manage/storages/StrmGenerate"
+import { StrmGenerate } from "~/pages/manage/storages/StrmGenerate"
+import { RightIcon } from "./Icon"
 
 export const ToolbarStrmGenerate = () => {
   const { pathname } = useRouter()
@@ -9,7 +11,11 @@ export const ToolbarStrmGenerate = () => {
   const isStrm = () => objStore.provider === "Strm"
   return (
     <Show when={isAdmin() && isStrm()}>
-      <StrmGenerateButton path={pathname()} />
+      <StrmGenerate path={pathname()}>
+        {({ start }) => (
+          <RightIcon as={TbFileExport} tips="generate_strm" onClick={start} />
+        )}
+      </StrmGenerate>
     </Show>
   )
 }

--- a/src/pages/manage/sidemenu_items.tsx
+++ b/src/pages/manage/sidemenu_items.tsx
@@ -24,7 +24,7 @@ import { Component, lazy } from "solid-js"
 import { joinBase } from "~/utils"
 import { Group, UserRole } from "~/types"
 import { FaSolidBook, FaSolidDatabase } from "solid-icons/fa"
-import { TbArchive, TbDevices2 } from "solid-icons/tb"
+import { TbArchive, TbDevices2, TbFileExport } from "solid-icons/tb"
 import { TbLink } from "solid-icons/tb"
 import { FaSolidUserGear } from "solid-icons/fa"
 import { BiRegularMessageAltDetail } from "solid-icons/bi"
@@ -179,6 +179,13 @@ export const side_menu_items: SideMenuItem[] = [
         to: "/@manage/tasks/copy",
         role: UserRole.GENERAL,
         component: lazy(() => import("./tasks/Copy")),
+      },
+      {
+        title: "manage.sidemenu.strm_generate",
+        icon: TbFileExport,
+        to: "/@manage/tasks/strm_generate",
+        role: UserRole.ADMIN,
+        component: lazy(() => import("./tasks/StrmGenerate")),
       },
       {
         title: "manage.sidemenu.decompress",

--- a/src/pages/manage/storages/Storage.tsx
+++ b/src/pages/manage/storages/Storage.tsx
@@ -69,7 +69,7 @@ function StorageOp(props: StorageProps) {
         }}
       />
       <Show when={props.storage.driver === "Strm"}>
-        <StrmGenerateButton path={props.storage.mount_path} size="sm" />
+        <StrmGenerateButton path={props.storage.mount_path} />
       </Show>
     </>
   )

--- a/src/pages/manage/storages/Storage.tsx
+++ b/src/pages/manage/storages/Storage.tsx
@@ -9,11 +9,13 @@ import {
   useColorModeValue,
   VStack,
 } from "@hope-ui/solid"
+import { Show } from "solid-js"
 import { useFetch, useRouter, useT } from "~/hooks"
 import { getMainColor } from "~/store"
 import { PEmptyResp, Storage } from "~/types"
 import { handleResp, handleRespWithNotifySuccess, notify, r } from "~/utils"
 import { DeletePopover } from "../common/DeletePopover"
+import { StrmGenerateButton } from "./StrmGenerate"
 
 interface StorageProps {
   storage: Storage
@@ -66,6 +68,9 @@ function StorageOp(props: StorageProps) {
           })
         }}
       />
+      <Show when={props.storage.driver === "Strm"}>
+        <StrmGenerateButton path={props.storage.mount_path} size="sm" />
+      </Show>
     </>
   )
 }

--- a/src/pages/manage/storages/StrmGenerate.tsx
+++ b/src/pages/manage/storages/StrmGenerate.tsx
@@ -1,0 +1,125 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Progress,
+  ProgressIndicator,
+  Text,
+  VStack,
+} from "@hope-ui/solid"
+import { createSignal, onCleanup, Show } from "solid-js"
+import { useT } from "~/hooks"
+import { r, notify, handleResp } from "~/utils"
+
+export type StrmGenerateButtonProps = {
+  path: string
+  size?: "xs" | "sm" | "md" | "lg"
+  colorScheme?: string
+}
+
+type TaskInfo = { id: string; progress: number; state: number; error: string }
+
+export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
+  const t = useT()
+  const [opened, setOpened] = createSignal(false)
+  const [progress, setProgress] = createSignal(0)
+  const [running, setRunning] = createSignal(false)
+  const [err, setErr] = createSignal("")
+  let timer: ReturnType<typeof setInterval> | undefined
+
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer)
+      timer = undefined
+    }
+  }
+  onCleanup(stop)
+
+  const poll = (tid: string) => {
+    stop()
+    timer = setInterval(async () => {
+      const resp = await r.post(`/admin/task/strm_generate/info?tid=${tid}`)
+      handleResp(resp, (info: TaskInfo) => {
+        if (info.error) {
+          stop()
+          setRunning(false)
+          setErr(info.error)
+          return
+        }
+        setProgress(Math.floor(info.progress))
+        if (info.progress >= 100) {
+          stop()
+          setRunning(false)
+          notify.success(t("global.generate_strm_done"))
+        }
+      })
+    }, 1000)
+  }
+
+  const start = async () => {
+    setOpened(true)
+    setRunning(true)
+    setProgress(0)
+    setErr("")
+    const resp = await r.post("/admin/strm/generate", { path: props.path })
+    handleResp(resp, (data: { task: TaskInfo }) => {
+      notify.info(t("global.generate_strm_start"))
+      poll(data.task.id)
+    })
+    if ((resp as any).code !== 200) {
+      setRunning(false)
+    }
+  }
+
+  const close = () => {
+    stop()
+    setOpened(false)
+  }
+
+  return (
+    <>
+      <Button
+        size={props.size ?? "sm"}
+        colorScheme={(props.colorScheme as any) ?? "accent"}
+        onClick={start}
+      >
+        {t("global.generate_strm")}
+      </Button>
+      <Modal opened={opened()} onClose={close} blockScrollOnMount={false}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>{t("global.generate_strm")}</ModalHeader>
+          <ModalBody>
+            <VStack spacing="$3" alignItems="stretch" py="$2">
+              <Progress value={progress()} trackColor="$neutral4">
+                <ProgressIndicator color="$success9" />
+              </Progress>
+              <Text>
+                <Show
+                  when={!err()}
+                  fallback={t("global.generate_strm_failed") + ": " + err()}
+                >
+                  {running()
+                    ? t("global.generate_strm_progress") +
+                      " " +
+                      progress() +
+                      "%"
+                    : t("global.generate_strm_done")}
+                </Show>
+              </Text>
+            </VStack>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="neutral" onClick={close}>
+              {t("global.close")}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/src/pages/manage/storages/StrmGenerate.tsx
+++ b/src/pages/manage/storages/StrmGenerate.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   VStack,
 } from "@hope-ui/solid"
-import { createSignal, onCleanup, Show } from "solid-js"
+import { createSignal, onCleanup } from "solid-js"
 import { useT } from "~/hooks"
 import { r, notify, handleResp } from "~/utils"
 
@@ -22,14 +22,18 @@ export type StrmGenerateButtonProps = {
 }
 
 type TaskInfo = { id: string; progress: number; state: number; error: string }
+type Status = "idle" | "running" | "done" | "failed"
 
 export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
   const t = useT()
   const [opened, setOpened] = createSignal(false)
   const [progress, setProgress] = createSignal(0)
-  const [running, setRunning] = createSignal(false)
+  const [status, setStatus] = createSignal<Status>("idle")
   const [err, setErr] = createSignal("")
   let timer: ReturnType<typeof setInterval> | undefined
+  // generation increments on every start/close/cleanup so any in-flight request
+  // or interval tick that resolves late can detect it is stale and bail out.
+  let generation = 0
 
   const stop = () => {
     if (timer) {
@@ -37,47 +41,83 @@ export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
       timer = undefined
     }
   }
-  onCleanup(stop)
+  onCleanup(() => {
+    generation++
+    stop()
+  })
 
-  const poll = (tid: string) => {
+  const fail = (msg: string) => {
+    stop()
+    setStatus("failed")
+    setErr(msg)
+  }
+
+  const poll = (gen: number, tid: string) => {
     stop()
     timer = setInterval(async () => {
       const resp = await r.post(`/admin/task/strm_generate/info?tid=${tid}`)
-      handleResp(resp, (info: TaskInfo) => {
-        if (info.error) {
-          stop()
-          setRunning(false)
-          setErr(info.error)
-          return
-        }
-        setProgress(Math.floor(info.progress))
-        if (info.progress >= 100) {
-          stop()
-          setRunning(false)
-          notify.success(t("global.generate_strm_done"))
-        }
-      })
+      if (gen !== generation) return
+      handleResp(
+        resp,
+        (info: TaskInfo) => {
+          if (gen !== generation) return
+          if (info.error) {
+            fail(info.error)
+            return
+          }
+          setProgress(Math.floor(info.progress))
+          if (info.progress >= 100) {
+            stop()
+            setStatus("done")
+            notify.success(t("global.generate_strm_done"))
+          }
+        },
+        (msg: string) => {
+          if (gen === generation) fail(msg)
+        },
+      )
     }, 1000)
   }
 
   const start = async () => {
+    stop()
+    const gen = ++generation
     setOpened(true)
-    setRunning(true)
+    setStatus("running")
     setProgress(0)
     setErr("")
     const resp = await r.post("/admin/strm/generate", { path: props.path })
-    handleResp(resp, (data: { task: TaskInfo }) => {
-      notify.info(t("global.generate_strm_start"))
-      poll(data.task.id)
-    })
-    if ((resp as any).code !== 200) {
-      setRunning(false)
-    }
+    if (gen !== generation) return
+    handleResp(
+      resp,
+      (data: { task: TaskInfo }) => {
+        if (gen !== generation) return
+        notify.info(t("global.generate_strm_start"))
+        poll(gen, data.task.id)
+      },
+      (msg: string) => {
+        if (gen === generation) fail(msg)
+      },
+    )
   }
 
   const close = () => {
+    generation++
     stop()
     setOpened(false)
+  }
+
+  const statusText = () => {
+    switch (status()) {
+      case "failed":
+        return t("global.generate_strm_failed") + ": " + err()
+      case "done":
+        return t("global.generate_strm_done")
+      case "running":
+        return t("global.generate_strm_progress") + " " + progress() + "%"
+      default:
+        return ""
+    }
   }
 
   return (
@@ -98,19 +138,7 @@ export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
               <Progress value={progress()} trackColor="$neutral4">
                 <ProgressIndicator color="$success9" />
               </Progress>
-              <Text>
-                <Show
-                  when={!err()}
-                  fallback={t("global.generate_strm_failed") + ": " + err()}
-                >
-                  {running()
-                    ? t("global.generate_strm_progress") +
-                      " " +
-                      progress() +
-                      "%"
-                    : t("global.generate_strm_done")}
-                </Show>
-              </Text>
+              <Text>{statusText()}</Text>
             </VStack>
           </ModalBody>
           <ModalFooter>

--- a/src/pages/manage/storages/StrmGenerate.tsx
+++ b/src/pages/manage/storages/StrmGenerate.tsx
@@ -11,9 +11,20 @@ import {
   Text,
   VStack,
 } from "@hope-ui/solid"
-import { createSignal, onCleanup } from "solid-js"
+import { createSignal, JSX, onCleanup, Show } from "solid-js"
 import { useT } from "~/hooks"
 import { r, notify, handleResp } from "~/utils"
+
+type TaskInfo = { id: string; progress: number; state: number; error: string }
+type Status = "idle" | "running" | "done" | "failed"
+
+export type StrmGenerateProps = {
+  path: string
+  // render-prop trigger: receives `start` to kick off generation. Lets callers
+  // render either a Button (storages page) or a toolbar icon while sharing the
+  // progress dialog + polling logic below.
+  children: (api: { start: () => void }) => JSX.Element
+}
 
 export type StrmGenerateButtonProps = {
   path: string
@@ -21,10 +32,7 @@ export type StrmGenerateButtonProps = {
   colorScheme?: string
 }
 
-type TaskInfo = { id: string; progress: number; state: number; error: string }
-type Status = "idle" | "running" | "done" | "failed"
-
-export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
+export const StrmGenerate = (props: StrmGenerateProps) => {
   const t = useT()
   const [opened, setOpened] = createSignal(false)
   const [progress, setProgress] = createSignal(0)
@@ -101,11 +109,20 @@ export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
     )
   }
 
+  // hide just closes the foreground window; the backend task keeps running and
+  // polling continues, so the success toast still fires and progress stays
+  // visible in the task center.
+  const hide = () => setOpened(false)
+
+  // close is used once the task reached a terminal state: stop polling and reset.
   const close = () => {
     generation++
     stop()
     setOpened(false)
   }
+
+  const isRunning = () => status() === "running"
+  const dismiss = () => (isRunning() ? hide() : close())
 
   const statusText = () => {
     switch (status()) {
@@ -122,14 +139,8 @@ export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
 
   return (
     <>
-      <Button
-        size={props.size ?? "sm"}
-        colorScheme={(props.colorScheme as any) ?? "accent"}
-        onClick={start}
-      >
-        {t("global.generate_strm")}
-      </Button>
-      <Modal opened={opened()} onClose={close} blockScrollOnMount={false}>
+      {props.children({ start })}
+      <Modal opened={opened()} onClose={dismiss} blockScrollOnMount={false}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>{t("global.generate_strm")}</ModalHeader>
@@ -139,15 +150,37 @@ export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
                 <ProgressIndicator color="$success9" />
               </Progress>
               <Text>{statusText()}</Text>
+              <Show when={isRunning()}>
+                <Text size="sm" color="$neutral10">
+                  {t("global.generate_strm_background")}
+                </Text>
+              </Show>
             </VStack>
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme="neutral" onClick={close}>
-              {t("global.close")}
+            <Button colorScheme="neutral" onClick={dismiss}>
+              {isRunning() ? t("global.generate_strm_hide") : t("global.close")}
             </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
     </>
+  )
+}
+
+export const StrmGenerateButton = (props: StrmGenerateButtonProps) => {
+  const t = useT()
+  return (
+    <StrmGenerate path={props.path}>
+      {({ start }) => (
+        <Button
+          size={props.size}
+          colorScheme={(props.colorScheme as any) ?? "accent"}
+          onClick={start}
+        >
+          {t("global.generate_strm")}
+        </Button>
+      )}
+    </StrmGenerate>
   )
 }

--- a/src/pages/manage/tasks/StrmGenerate.tsx
+++ b/src/pages/manage/tasks/StrmGenerate.tsx
@@ -1,0 +1,23 @@
+import { useManageTitle, useT } from "~/hooks"
+import { TypeTasks } from "./Tasks"
+
+const StrmGenerate = () => {
+  const t = useT()
+  useManageTitle("manage.sidemenu.strm_generate")
+  return (
+    <TypeTasks
+      type="strm_generate"
+      canRetry
+      nameAnalyzer={{
+        // backend name: `generate strm [<mount>](<path>)`
+        regex: /^generate strm \[(.+)]\((.*)\)$/,
+        title: (matches) => matches[1],
+        attrs: {
+          [t(`tasks.attr.strm_generate.path`)]: (matches) => matches[2] || "/",
+        },
+      }}
+    />
+  )
+}
+
+export default StrmGenerate


### PR DESCRIPTION
## What

Frontend for **one-click STRM generation** (companion to the alist backend PR adding `POST /api/admin/strm/generate` + the `strm_generate` task group).

## Changes

- **Generate button (two entry points)**
  - Storages management page: a "Generate Strm" button on each Strm storage row, aligned to the default row-button height.
  - File browser toolbar: an icon (`RightIcon`) — shown only to admins when the current storage provider is `Strm` — matching the other toolbar icons.
- **Shared progress dialog** — both entry points share a render-prop core holding the progress modal + task polling, with stale-poll guards so late responses/ticks bail out.
- **Hideable progress window** — hiding the dialog while a task is running keeps the backend task running and polling alive (success toast still fires); only terminal states fully reset.
- **Task center integration** — registers `strm_generate` in the manage sidebar (admin) and adds a task page so generation is trackable/retriable like copy/upload tasks.
- **i18n** — English strings only (`global`, `home`, `manage`, `tasks`); other languages via Crowdin.

## Notes

- All admin-gated. Requires the backend PR for the endpoint + task group.
