### PR TITLE
feat(copy): add skip existing files option to copy dialog

### DIFF
--- a/src/pages/home/toolbar/CopyMove.tsx
+++ b/src/pages/home/toolbar/CopyMove.tsx
@@ -12,10 +12,12 @@ export const Copy = () => {
   const { pathname } = useRouter()
   const { refresh } = usePath()
   const [overwrite, setOverwrite] = createSignal(false)
+  const [skipExisting, setSkipExisting] = createSignal(false)
   const handler = (name: string) => {
     if (name === "copy") {
       onOpen()
       setOverwrite(false)
+      setSkipExisting(false)
     }
   }
   bus.on("tool", handler)
@@ -29,15 +31,29 @@ export const Copy = () => {
       onClose={onClose}
       loading={loading()}
       footerSlot={
-        <Checkbox
-          mr="auto"
-          checked={overwrite()}
-          onChange={() => {
-            setOverwrite(!overwrite())
-          }}
-        >
-          {t("home.conflict_policy.overwrite_existing")}
-        </Checkbox>
+        <>
+          <Checkbox
+            disabled={skipExisting()}
+            checked={overwrite()}
+            onChange={() => {
+              setOverwrite(!overwrite())
+            }}
+          >
+            {t("home.conflict_policy.overwrite_existing")}
+          </Checkbox>
+          <Checkbox
+            mr="auto"
+            checked={skipExisting()}
+            onChange={() => {
+              setSkipExisting(!skipExisting())
+              if (skipExisting()) {
+                setOverwrite(false)
+              }
+            }}
+          >
+            {t("home.conflict_policy.skip_existing")}
+          </Checkbox>
+        </>
       }
       onSubmit={async (dst) => {
         const resp = await ok(
@@ -45,6 +61,7 @@ export const Copy = () => {
           dst,
           selectedObjs().map((obj) => obj.name),
           overwrite(),
+          skipExisting(),
         )
         handleRespWithNotifySuccess(resp, () => {
           refresh()

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -116,8 +116,15 @@ export const fsCopy = (
   dst_dir: string,
   names: string[],
   overwrite: boolean,
+  skip_existing?: boolean,
 ): PEmptyResp => {
-  return r.post("/fs/copy", { src_dir, dst_dir, names, overwrite })
+  return r.post("/fs/copy", {
+    src_dir,
+    dst_dir,
+    names,
+    overwrite,
+    skip_existing,
+  })
 }
 
 export const fsRemove = (dir: string, names: string[]): PEmptyResp => {


### PR DESCRIPTION
Ref AlistGo/alist#9555，配套后端 PR：AlistGo/alist#9557

复制对话框在「覆盖已有文件」旁新增「跳过已存在文件」复选框：

- 勾选后请求携带 `skip_existing: true`，后端跳过目标已存在的同名同大小文件，实现中断后续传；
- 勾选「跳过」时「覆盖」复选框自动禁用并取消勾选（两者互斥）；
- 复用已有 i18n key `home.conflict_policy.skip_existing`，无需新增文案；
- 打开对话框时两个选项均重置为未勾选。

`vite build` 通过。