### PR TITLE
feat(settings): add the 123 Open offline download temp dir

### DIFF
--- a/src/lang/en/settings_other.json
+++ b/src/lang/en/settings_other.json
@@ -20,6 +20,8 @@
   "set_thunder": "Set Thunder",
   "guangyapan": "GuangYaPan",
   "set_guangyapan": "Set GuangYaPan",
+  "123_open": "123 Open",
+  "set_123_open": "Set 123 Open",
   "frp": "FRP Intranet Tunnel",
   "frp_save_apply": "Save & Apply",
   "frp_stop": "Stop FRP",

--- a/src/pages/manage/settings/Other.tsx
+++ b/src/pages/manage/settings/Other.tsx
@@ -27,6 +27,7 @@ const OtherSettings = () => {
   const [pikpakTempDir, setPikPakTempDir] = createSignal("")
   const [thunderTempDir, setThunderTempDir] = createSignal("")
   const [guangYaPanTempDir, setGuangYaPanTempDir] = createSignal("")
+  const [open123TempDir, setOpen123TempDir] = createSignal("")
   const [token, setToken] = createSignal("")
   const [settings, setSettings] = createSignal<SettingItem[]>([])
   const [settingsLoading, settingsData] = useFetch(
@@ -75,6 +76,12 @@ const OtherSettings = () => {
         temp_dir: guangYaPanTempDir(),
       }),
   )
+  const [setOpen123Loading, setOpen123] = useFetch(
+    (): PResp<string> =>
+      r.post("/admin/setting/set_123_open", {
+        temp_dir: open123TempDir(),
+      }),
+  )
   const [setTokenLoading, setTokenRequest] = useFetch(
     (): PResp<string> => r.post("/admin/setting/set_token", { token: token() }),
   )
@@ -103,6 +110,9 @@ const OtherSettings = () => {
       )
       setGuangYaPanTempDir(
         data.find((i) => i.key === "guangyapan_temp_dir")?.value || "",
+      )
+      setOpen123TempDir(
+        data.find((i) => i.key === "123_open_temp_dir")?.value || "",
       )
       setSettings(data)
     })
@@ -281,6 +291,29 @@ const OtherSettings = () => {
         }}
       >
         {t("settings_other.set_guangyapan")}
+      </Button>
+      <Heading my="$2">{t("settings_other.123_open")}</Heading>
+      <FormControl w="$full" display="flex" flexDirection="column">
+        <FormLabel for="123_open_temp_dir" display="flex" alignItems="center">
+          {t(`settings.123_open_temp_dir`)}
+        </FormLabel>
+        <FolderChooseInput
+          id="123_open_temp_dir"
+          value={open123TempDir()}
+          onChange={(path) => setOpen123TempDir(path)}
+        />
+      </FormControl>
+      <Button
+        my="$2"
+        loading={setOpen123Loading()}
+        onClick={async () => {
+          const resp = await setOpen123()
+          handleResp(resp, (data) => {
+            notify.success(data)
+          })
+        }}
+      >
+        {t("settings_other.set_123_open")}
       </Button>
       <Heading my="$2">{t("settings.token")}</Heading>
       <Input


### PR DESCRIPTION
Companion to AlistGo/alist#9602, which adds 123 Open as an offline download tool.

The offline download settings page carries one card per cloud tool (115, PikPak, Thunder, GuangYaPan), each writing its scratch directory through that tool's own endpoint rather than the generic settings form. Without a card, the `123_open_temp_dir` setting has no way to be written from the UI, and the tool never becomes ready — it gates `IsReady()` on that directory pointing at a working 123 Open storage, exactly like its siblings.

This adds the matching card, backed by `POST /admin/setting/set_123_open`.

Driver field translations (`drivers.json`) are generated from the backend struct tags by the `auto_lang` workflow, so only the page strings are added here.

Verified against a local build served by the backend branch: the card renders, saving rejects a non-123 storage ("unsupported storage driver for offline download, only 123 Open is supported") and a storage that failed to initialise ("storage not init: …"), and the saved value is read back into the field on reload.